### PR TITLE
Fix the type of inspect_request.cursor_pos

### DIFF
--- a/lib/core/JupyterShellMessage.ml
+++ b/lib/core/JupyterShellMessage.ml
@@ -52,7 +52,7 @@ type execute_reply =
 type inspect_request =
   {
     code : string;
-    cursor_pos : bool;
+    cursor_pos : int;
     detail_level : int [@default 0];
   } [@@deriving yojson { strict = false }]
 


### PR DESCRIPTION
Issue: #13 

According to [Messaging in Jupyter](http://jupyter-client.readthedocs.io/en/latest/messaging.html),
`inspect_request` is activated by `x?` or `x??` inputs.