### PR TITLE
Fix interruption behavior

### DIFF
--- a/src/JupyterMain.ml
+++ b/src/JupyterMain.ml
@@ -55,11 +55,12 @@ let () =
   let ctx = ZMQ.Context.create () in
   let heartbeat = start_heartbeat ~ctx conn_info in
   let server = Server.create ~repl ~ctx conn_info in
+  let server_thread = Server.start server in
   Sys.catch_break true ; (* Catch `Interrupt' signal *)
   let rec main () =
     try
       Lwt_main.run begin
-        let%lwt () = Server.start server <?> heartbeat in
+        let%lwt () = server_thread <?> heartbeat in
         Server.close server
       end
     with Sys.Break ->


### PR DESCRIPTION
- [x] Multiple kernel threads are running: interruption signal copies a kernel server thread in `Lwt_main.run`. The number of execution results after interruption signal should be one, but two or more results were shown.
- [ ] `#thread` breaks the interruption behavior, e.g., interruption during `Unix.sleep 10` should return immediately, but an execution result is shown after 10 seconds.

The latter problem is not solved, but the following code can be interrupted correctly:

```ocaml
let rec aux i =
    Format.printf "i = %d@." i ;
    if i > 0 then begin
        Unix.sleep 1 ;
        aux (pred i)
    end
in
aux 10
```

and IO can be also interrupted:

```ocaml
let a, b = Unix.pipe () in
let ic = Unix.in_channel_of_descr a in
input_line ic
```