### PR TITLE
Disable SIGINT during sending `Abort to kernel

### DIFF
--- a/lib/repl/JupyterReplProcess.ml
+++ b/lib/repl/JupyterReplProcess.ml
@@ -79,19 +79,24 @@ let create_child_process ?preload ?init_file ~ctrlin ~ctrlout ~jupyterin =
     Marshal.to_channel ctrlout resp flags ;
     flush ctrlout
   in
-  let rec aux () =
+  let rec loop () =
     try
       match Marshal.from_channel ctrlin with
       | Quit -> exit 0 (* Shutdown request *)
       | Exec (ctx, filename, code) ->
         context := ctx ;
         JupyterReplToploop.run ~filename code ~init:() ~f:(fun () -> send) ;
-        send `Prompt ; aux ()
+        send `Prompt ; loop ()
     with
     | End_of_file -> exit 0 (* control channel is closed. *)
-    | Sys.Break -> send `Abort ; send `Prompt ; aux () (* Interrupted *)
+    | Sys.Break ->
+      let handler' = Sys.(signal sigint (Signal_handle (fun _ -> ()))) in
+      send `Abort ;
+      send `Prompt ;
+      ignore Sys.(signal sigint handler') ;
+      loop ()
   in
-  aux ()
+  loop ()
 
 let recv_ctrlout_thread ~push ic =
   let rec loop () =


### PR DESCRIPTION
SIGINT during ``send `Abort`` crashes REPL process. SIGINT should be ignored then.