### PR TITLE
Step-by-step execution of cells

### DIFF
--- a/lib/kernel/JupyterKernelServer.mli
+++ b/lib/kernel/JupyterKernelServer.mli
@@ -37,8 +37,9 @@ sig
       control : ShellChannel.t;
       iopub : IopubChannel.t;
       stdin : StdinChannel.t;
-      code : Buffer.t; (* code that have been executed ever *)
+      code : Buffer.t; (* code that have been executed ever (for merlin completion) *)
 
+      execution_result : (Jupyter.ShellMessage.status * string option) Lwt_mvar.t;
       mutable execution_count : int;
       mutable current_parent : ShellChannel.input option;
     }


### PR DESCRIPTION
This is hotfix for issue #54.

Execution results of previous (or older) cells are displayed under the next cell as follows:

```ocaml
# let x = Unix.sleep 10 ; 10 ;;
# let y = 20 ;;
val x : int = 10
val y : int = 20
```

The above result should be

```ocaml
# let x = Unix.sleep 10 ; 10 ;;
val x : int = 10
# let y = 20 ;;
val y : int = 20
```

This problem is observed when we execute a cell before older cells are not finished.
The kernel needs to respond to an execution result message to the corresponding cell.
However the kernel replies all execution results to the last executed cell.
The new kernel waits execution of the previous cell and sends a result to the corresponding cell correctly.

@Naereen Could you check the behavior of the new version?