### PR TITLE
Simply support jupyter-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # OCaml Jupyter
 
-[![Kernel version][version-img]][version] [![Jupyter protocol][protocol-img]][protocol] [![License][license-img]][license] [![Travis Build Status][travis-img]][travis]
+[![Jupyter protocol][protocol-img]][protocol] [![License][license-img]][license] [![Travis Build Status][travis-img]][travis]
 
-[version]:      https://github.com/akabe/ocaml-jupyter/releases
-[version-img]:  https://img.shields.io/badge/version-1.1.0-blue.svg
 [license]:      https://github.com/akabe/ocaml-jupyter/blob/master/LICENSE
 [license-img]:  https://img.shields.io/badge/license-MIT-blue.svg
 [protocol]:     http://jupyter-client.readthedocs.io/en/stable/messaging.html
@@ -29,20 +27,18 @@ $ opam install jupyter
 $ opam install jupyter-archimedes  # Jupyter-friendly 2D plotting library
 ```
 
-which will automatically register the kernel to Jupyter if `jupyter` command is found.
-Otherwise (i.e., the command is not found in `$PATH`, or you have not installed Jupyter yet)
-you need to manually install the kernel:
+which will automatically add the kernel to Jupyter. You can use `ocaml-jupyter` kernel by launching Jupyter notebook server:
+
+```console
+$ jupyter notebook
+```
+
+If you have not installed Jupyter yet (or `jupyter` command was not found in `$PATH`), you need to manually register the kernel:
 
 ```console
 $ jupyter kernelspec install --name ocaml-jupyter "$(opam config var share)/ocaml-jupyter"
 [InstallKernelSpec] Removing existing kernelspec in /home/USERNAME/.local/share/jupyter/kernels/ocaml-jupyter
 [InstallKernelSpec] Installed kernelspec ocaml-jupyter-4.04.2 in /home/USERNAME/.local/share/jupyter/kernels/ocaml-jupyter
-```
-
-After installation, you can use `ocaml-jupyter` kernel by launching Jupyter notebook server:
-
-```console
-$ jupyter notebook
 ```
 
 ### Development version
@@ -103,10 +99,10 @@ OCaml Jupyter includes some sub-packages:
 - [jupyter.comm][jupyter-comm] is a library for communication between OCaml notebooks and Jupyter/Web frontend.
 - [jupyter-archimedes][jupyter-archimedes] is Jupyter backend of [Archimedes][archimedes], an easy-to-use 2D plotting library. This package only registers the `jupyter` backend to Archimedes, and provides empty interface.
 
-[jupyter-core]:       https://akabe.github.io/ocaml-jupyter/api/jupyter/index.html
-[jupyter-notebook]:   https://akabe.github.io/ocaml-jupyter/api/jupyter.notebook/index.html
-[jupyter-comm]:       https://akabe.github.io/ocaml-jupyter/api/jupyter.comm/index.html
-[jupyter-archimedes]: https://akabe.github.io/ocaml-jupyter/api/jupyter-archimedes/index.html
+[jupyter-core]:       https://akabe.github.io/ocaml-jupyter/api/jupyter/
+[jupyter-notebook]:   https://akabe.github.io/ocaml-jupyter/api/jupyter.notebook/
+[jupyter-comm]:       https://akabe.github.io/ocaml-jupyter/api/jupyter.comm/
+[jupyter-archimedes]: https://akabe.github.io/ocaml-jupyter/api/jupyter-archimedes/
 [archimedes]:         http://archimedes.forge.ocamlcore.org/
 
 ### Customize kernel parameters
@@ -199,3 +195,11 @@ We welcome your patch!
 3. Create a new branch and commit your changes.
 4. `git push` the commits into your (forked) repository.
 5. Pull request to `master` of this repository from the branch you pushed.
+
+Environment variable `LWT_LOG` controls a log level of OCaml Jupyter kernel.
+The following setting verbosely outputs log messages. They might help your debug.
+
+```console
+$ export LWT_LOG='* -> debug'
+$ jupyter notebook
+```

--- a/jupyter/src/core/shell.ml
+++ b/jupyter/src/core/shell.ml
@@ -80,6 +80,39 @@ type complete_reply =
     cmpl_status : status Json.enum [@key "status"];
   } [@@deriving yojson { strict = false }]
 
+(** {2 History} *)
+
+type history_request =
+  {
+    hist_output : bool [@key "output"];
+    hist_raw : bool [@key "raw"];
+    hist_access_type : string [@key "hist_access_type"];
+    hist_session : int option [@key "session"] [@default None];
+    hist_start : int option [@key "start"] [@default None];
+    hist_stop : int option [@key "stop"] [@default None];
+    hist_n : int [@key "n"];
+    hist_pattern : string option [@key "pattern"] [@default None];
+    hist_unique : bool [@key "unique"] [@default false];
+  } [@@deriving yojson { strict = false }]
+
+type history_reply =
+  {
+    history : (int option * int * string) list;
+  } [@@deriving yojson { strict = false }]
+
+(** {2 Code completeness} *)
+
+type is_complete_request =
+  {
+    is_cmpl_code : string [@key "code"];
+  } [@@deriving yojson { strict = false }]
+
+type is_complete_reply =
+  {
+    is_cmpl_status : string [@key "status"];
+    is_cmpl_indent : string option [@key "indent"] [@default None];
+  } [@@deriving yojson { strict = false }]
+
 (** {2 Connect} *)
 
 type connect_reply =
@@ -177,6 +210,8 @@ type request =
   | SHELL_EXEC_REQ of exec_request [@name "execute_request"]
   | SHELL_INSPECT_REQ of inspect_request [@name "inspect_request"]
   | SHELL_COMPLETE_REQ of complete_request [@name "complete_request"]
+  | SHELL_HISTORY_REQ of history_request [@name "history_request"]
+  | SHELL_IS_COMPLETE_REQ of is_complete_request [@name "is_complete_request"]
   | SHELL_CONNECT_REQ [@name "connect_request"]
   | SHELL_COMM_INFO_REQ of comm_info_request [@name "comm_info_request"]
   | SHELL_SHUTDOWN_REQ of shutdown [@name "shutdown_request"]
@@ -192,6 +227,8 @@ type reply =
   | SHELL_EXEC_REP of exec_reply [@name "execute_reply"]
   | SHELL_INSPECT_REP of inspect_reply [@name "inspect_reply"]
   | SHELL_COMPLETE_REP of complete_reply [@name "complete_reply"]
+  | SHELL_HISTORY_REP of history_reply [@name "history_reply"]
+  | SHELL_IS_COMPLETE_REP of is_complete_reply [@name "is_complete_reply"]
   | SHELL_CONNECT_REP of connect_reply [@name "connect_reply"]
   | SHELL_COMM_INFO_REP of comm_info_reply [@name "comm_info_reply"]
   | SHELL_SHUTDOWN_REP of shutdown [@name "shutdown_reply"]

--- a/jupyter/src/kernel/jbuild
+++ b/jupyter/src/kernel/jbuild
@@ -17,6 +17,7 @@
                 jupyter_repl
                 jupyter_completor
                 jupyter_log
+                str
                 lwt
                 lwt.unix
                 yojson

--- a/jupyter/src/kernel/message_channel.ml
+++ b/jupyter/src/kernel/message_channel.ml
@@ -69,7 +69,7 @@ struct
     match aux [] str_lst with
     | ids, hmac :: header :: parent_header :: metadata :: content :: buffers ->
       let open Jupyter.Message in
-      debug
+      info
         "RECV: HMAC=%s; header=%s; parent=%s; content=%s; metadata=%s"
         hmac header parent_header content metadata ;
       Hmac.validate ?key ~hmac ~header ~parent_header ~metadata ~content () ;
@@ -106,7 +106,7 @@ struct
       Hmac.encode ?key:ch.key
         ~header ~parent_header ~metadata:resp.metadata ~content ()
     in
-    debug
+    info
       "SEND: HMAC=%s; header=%s; parent=%s; content=%s; metadata=%s"
       hmac header parent_header content resp.metadata ;
     [

--- a/jupyter/src/repl/process.ml
+++ b/jupyter/src/repl/process.ml
@@ -195,7 +195,7 @@ let close repl =
 let heartbeat repl =
   let open Unix in
   match waitpid [WNOHANG; WUNTRACED] repl.pid with
-  | 0, _ -> info "REPL is healthy"
+  | 0, _ -> debug "REPL is healthy"
   | _, WEXITED i -> failwith (sprintf "Exited status %d" i)
   | _, WSIGNALED i -> failwith (sprintf "Killed by signal %d" i)
   | _, WSTOPPED i -> failwith (sprintf "Stopped by signal %d" i)


### PR DESCRIPTION
Death of ocaml-jupyter on jupyter-console is reported in issue #59. It is the cause of the bug that ocaml-jupyter does not support `history_request` and `is_complete_request` message (used by jupyter-console, not by jupyter notebook) of Jupyter protocol v5. This PR simply returns empty replies to the requests. jupyter-console does not crash (but outputs non-critical warnings):

```console
$ jupyter-console --kernel='ocaml-jupyter'
Jupyter console 5.1.0

None


In [1]: let x = 1 + 3 + 5
Out[1]: 
val x : int = 9


In [2]: #show List
  warn('The kernel did not respond properly to an is_complete_request: %s.' % str(msg))
In [2]: #show List
module List :
  sig
    val length : 'a list -> int
    val cons : 'a -> 'a list -> 'a list
    val hd : 'a list -> 'a
    val tl : 'a list -> 'a list
    val nth : 'a list -> int -> 'a
    val rev : 'a list -> 'a list
    ...
```

I think that improvement of usability on jupyter-console is unnecessary because utop is enough useful REPL for OCaml.