### PR TITLE
Prevent merlin errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,13 @@ script:
   - ocamlfind query jupyter.notebook
   - ocamlfind query jupyter.comm
   - ocamlfind query jupyter-archimedes
-  # unit and integration tests
-  - echo '#use "topfind" ;;' > $HOME/.ocamlinit # required for integration tests
-  - jupyter kernelspec install --user --name ocaml-jupyter "$(opam config var share)/jupyter"
+  # unit tests
   - jbuilder runtest
+  # integration tests
+  - echo '#use "topfind" ;;' > $HOME/.ocamlinit
+  - jupyter kernelspec install --user --name ocaml-jupyter "$(opam config var share)/jupyter"
+  - jbuilder build test/integration/runtest.exe
+  - ./_build/default/test/integration/runtest.exe test/integration/suite/*.ml
   # uninstallation
   - opam remove jupyter jupyter-archimedes --verbose
   - (! ocamlfind query jupyter)

--- a/jupyter/src/completor/merlin.ml
+++ b/jupyter/src/completor/merlin.ml
@@ -187,7 +187,7 @@ let complete_range ~doc ~types ~cursor_start ~cursor_end merlin code =
   let prefix = String.sub code cursor_start len in
   info "completion prefix = %S (%d--%d)" prefix cursor_start cursor_end ;
   let args = [
-    "-position"; sprintf "%d:%d" (cursor_start + offset) (cursor_end + offset);
+    "-position"; string_of_int (cursor_end + offset);
     "-prefix"; prefix;
     "-doc"; string_of_bool doc;
     "-types"; string_of_bool types;

--- a/jupyter/src/completor/merlin.ml
+++ b/jupyter/src/completor/merlin.ml
@@ -51,19 +51,19 @@ let call merlin command flags printer =
   let mode = if merlin.server then "server" else "single" in
   let args = merlin.bin_path :: mode :: command
              :: "-dot-merlin" :: merlin.dot_merlin :: flags in
-  [%to_yojson: string list] args
-  |> Yojson.Safe.to_string
-  |> info "Merlin command: %s" ;
+  info "Merlin command: %s" (String.concat " " args) ;
   let proc = Lwt_process.open_process ("ocamlmerlin", Array.of_list args) in
   let%lwt () = printer proc#stdin in
   let%lwt () = Lwt_io.flush proc#stdin in
   let%lwt () = Lwt_io.close proc#stdin in
   match%lwt Lwt_io.read_line proc#stdout with
-  | exception End_of_file -> failwith "merlin crashed or not found ocamlmerlin"
+  | exception End_of_file ->
+    warning "merlin crashed or not found ocamlmerlin" ;
+    Lwt.return_none
   | str ->
     let%lwt _ = proc#close in
     debug "Merlin returns: %s" str ;
-    Lwt.return str
+    Lwt.return_some str
 
 (** {2 Top-level merlin replies} *)
 
@@ -83,8 +83,8 @@ type 'a merlin_reply_body =
 [@@deriving of_yojson { strict = false }]
 
 let parse_merlin_reply ~of_yojson str =
-  let failwith_json msg json =
-    failwith (sprintf "%s: %s" msg (Yojson.Safe.pretty_to_string json))
+  let error_json msg json =
+    error "%s: %s" msg (Yojson.Safe.pretty_to_string json)
   in
   let reply = Yojson.Safe.from_string str
               |> [%of_yojson: Yojson.Safe.json merlin_reply_body]
@@ -93,10 +93,10 @@ let parse_merlin_reply ~of_yojson str =
   |> merlin_reply_of_yojson of_yojson
   |> Jupyter.Json.or_die
   |> function
-  | RETURN ret -> ret
-  | FAILURE j -> failwith_json "Merlin failure" j
-  | ERROR j -> failwith_json "Merlin error" j
-  | EXN j -> failwith_json "Merlin exception" j
+  | RETURN ret -> Some ret
+  | FAILURE j -> error_json "Merlin failure" j ; None
+  | ERROR j -> error_json "Merlin error" j ; None
+  | EXN j -> error_json "Merlin exception" j ; None
 
 (** {2 Detection of identifiers} *)
 
@@ -118,7 +118,13 @@ let occurrences ~pos merlin code =
   let args = ["-identifier-at"; string_of_int pos] in
   let printer oc = Lwt_io.write oc code in
   call merlin "occurrences" args printer
-  >|= parse_merlin_reply ~of_yojson:[%of_yojson: ident_reply list]
+  >|= function
+  | None -> []
+  | Some s ->
+    parse_merlin_reply ~of_yojson:[%of_yojson: ident_reply list] s
+    |> function
+    | None -> []
+    | Some replies -> replies
 
 let abs_position code pos =
   let n = String.length code in
@@ -190,11 +196,16 @@ let complete_range ~doc ~types ~cursor_start ~cursor_end merlin code =
     let%lwt () = Lwt_io.write oc context in
     Lwt_io.write oc code in
   call merlin "complete-prefix" args printer
-  >|= parse_merlin_reply ~of_yojson:[%of_yojson: reply]
-  >|= fun reply ->
-  { reply with
-    cmpl_start = rfind_cursor_start code cursor_end;
-    cmpl_end = cursor_end; }
+  >|= function
+  | None -> empty
+  | Some s ->
+    parse_merlin_reply ~of_yojson:[%of_yojson: reply] s
+    |> function
+    | None -> empty
+    | Some reply ->
+      { reply with
+        cmpl_start = rfind_cursor_start code cursor_end;
+        cmpl_end = cursor_end; }
 
 let complete ?(doc = false) ?(types = false) ~pos merlin code =
   match%lwt occurrences merlin ~pos code with

--- a/test/completor/test_merlin.ml
+++ b/test/completor/test_merlin.ml
@@ -94,6 +94,18 @@ let complete ?doc ?types merlin ~pos code =
 let test_complete ctxt =
   let require ?msg x y = assert_equal ~ctxt ~printer:[%show: reply] ?msg x y in
   let merlin = Merlin.create () in
+  let code = "List" in
+  let expected = Merlin.{
+      cmpl_start = 0; cmpl_end = 4;
+      cmpl_candidates = [
+        { cmpl_name = "List"; cmpl_kind = CMPL_MODULE;
+          cmpl_type = ""; cmpl_doc = ""; };
+        { cmpl_name = "ListLabels"; cmpl_kind = CMPL_MODULE;
+          cmpl_type = ""; cmpl_doc = ""; };
+      ];
+    } in
+  let actual = complete merlin code ~pos:4 in
+  require expected actual ~msg:"at the first of code" ;
   let code = "let _ = List.ma " in
   let expected = Merlin.{
       cmpl_start = 13; cmpl_end = 15;

--- a/test/integration/.gitignore
+++ b/test/integration/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints
+*.ipynb

--- a/test/integration/jbuild
+++ b/test/integration/jbuild
@@ -11,15 +11,3 @@
                ppx_deriving.runtime))
   (flags      ((:include ${ROOT}/config/ocaml_flags.sexp)
                (:include ${ROOT}/config/ocaml_test_flags.sexp)))))
-
-(alias
- ((name   runtest)
-  (deps   (runtest.exe
-           suite/ppx.ml
-           suite/jupyter-notebook.ml
-           suite/jupyter-archimedes.ml))
-  (action (chdir ${ROOT}/test/integration
-                 (run ${<}
-                      suite/ppx.ml
-                      suite/jupyter-notebook.ml
-                      suite/jupyter-archimedes.ml)))))


### PR DESCRIPTION
The current kernel has a critical bug:

```ocaml
List<Tab>
```

causes

```
Error: Socket not closed before finalization
Error: Socket not closed before finalization
Error: Socket not closed before finalization
Error: Socket not closed before finalization
Error: Socket not closed before finalization
Error: Context not closed before finalization
Fatal error: exception Failure("Merlin exception: \"Invalid_argument(\\\"Msource.find_line: invalid line number 0. Numbering starts from 1\\\")\\nRaised at file \\\"pervasives.ml\\\", line 33, characters 20-45\\nCalled from file \\\"src/kernel/msource.ml\\\", line 45, characters 4-107\\nCalled from file \\\"src/kernel/msource.ml\\\", line 64, characters 15-31\\nCalled from file \\\"src/kernel/msource.ml\\\", line 98, characters 12-36\\nCalled from file \\\"src/kernel/msource.ml\\\", line 127, characters 18-34\\nCalled from file \\\"src/kernel/mreader.ml\\\", line 43, characters 16-52\\nCalled from file \\\"src/kernel/mpipeline.ml\\\", line 84, characters 19-68\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"src/kernel/mpipeline.ml\\\", line 13, characters 10-22\\nRe-raised at file \\\"src/kernel/mpipeline.ml\\\", line 15, characters 34-49\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"src/kernel/mpipeline.ml\\\", line 13, characters 10-22\\nRe-raised at file \\\"src/kernel/mpipeline.ml\\\", line 15, characters 34-49\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"src/kernel/mpipeline.ml\\\", line 13, characters 10-22\\nRe-raised at file \\\"src/kernel/mpipeline.ml\\\", line 15, characters 34-49\\nCalled from file \\\"camlinternalLazy.ml\\\", line 27, characters 17-27\\nRe-raised at file \\\"camlinternalLazy.ml\\\", line 34, characters 4-11\\nCalled from file \\\"src/kernel/mpipeline.ml\\\" (inlined), line 73, characters 21-30\\nCalled from file \\\"src/frontend/query_commands.ml\\\", line 71, characters 14-45\\nCalled from file \\\"src/frontend/new/new_commands.ml\\\", line 50, characters 15-53\\nCalled from file \\\"src/utils/std.ml\\\", line 638, characters 8-12\\nRe-raised at file \\\"src/utils/std.ml\\\", line 640, characters 30-39\\nCalled from file \\\"src/utils/misc.ml\\\", line 30, characters 20-27\\nRe-raised at file \\\"src/utils/misc.ml\\\", line 30, characters 50-57\\nCalled from file \\\"src/frontend/new/new_merlin.ml\\\", line 135, characters 18-54\\n\"")
Raised at file "src/core/lwt.ml", line 2719, characters 18-25
Called from file "src/unix/lwt_main.ml", line 33, characters 8-18
Called from file "jupyter/bin/jupyter_main.ml", line 63, characters 6-100
Called from file "jupyter/bin/jupyter_main.ml", line 71, characters 2-9
[I 22:47:51.110 NotebookApp] KernelRestarter: restarting kernel (1/5)
```

`-position X:Y` argument for `ocamlmerlin` command seems wrong.