### PR TITLE
Set true to Sys.interactive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
   - pip install --user ipython==5.4.1 jupyter
   - curl -L https://gist.githubusercontent.com/akabe/24979afbf95c4cf4393f589cda997e1b/raw/install_opam.sh | sh -xeu
   - eval $(opam config env)
-  - opam install -y ocamlfind 'merlin>=3.0.0' ocp-indent camlp4 'ounit>=2.0.0'
+  - opam install -y ocamlfind 'merlin>=3.0.0' ocp-indent camlp4 'ounit>=2.0.0' core
   - opam remove jupyter
 
 script:

--- a/jupyter/src/repl/jbuild
+++ b/jupyter/src/repl/jbuild
@@ -13,6 +13,7 @@
   (preprocess  (pps (lwt.ppx)))
   (libraries   (jupyter
                 jupyter_log
+                str
                 lwt
                 lwt.unix
                 compiler-libs.common

--- a/jupyter/src/repl/process.ml
+++ b/jupyter/src/repl/process.ml
@@ -122,8 +122,8 @@ let recv_stdout_thread ~push ~ctx ~name ic =
         push (Some (Message.IOPUB_REP msg))
       | None ->
         match name with
-        | Iopub.IOPUB_STDOUT -> notice "STDOUT>> %s@." line
-        | Iopub.IOPUB_STDERR -> notice "STDERR>> %s@." line)
+        | Iopub.IOPUB_STDOUT -> notice "STDOUT>> %s" line
+        | Iopub.IOPUB_STDERR -> notice "STDERR>> %s" line)
 
 let create ?preload ?init_file ?error_ctx_size () =
   let c_jupyterin, p_jupyterin = Unix.pipe () in

--- a/test/integration/suite/core-top.ml
+++ b/test/integration/suite/core-top.ml
@@ -1,0 +1,4 @@
+#thread ;;
+#require "core.top" ;;
+
+Core.Time.now () ;;

--- a/test/repl/test_process.ml
+++ b/test/repl/test_process.ml
@@ -87,7 +87,7 @@ let test__capture_stderr ctxt =
 let test__sys_interactive ctxt =
   let actual = eval "!Sys.interactive" |> map_content in
   let expected = [
-    Iopub (iopub_success ~count:0 "- : bool = false\n");
+    Iopub (iopub_success ~count:0 "- : bool = true\n");
     Shell (execute_reply ~count:0 SHELL_OK);
   ] in
   assert_equal ~ctxt ~printer:[%show: reply list] expected actual


### PR DESCRIPTION
Issue: #78

`Sys.interactive` controls loading `ocamltoplevel.cma` inside OCaml top level at [toplevel/toploop.ml](https://github.com/ocaml/ocaml/blob/4.05.0/toplevel/toploop.ml#L467-L469).
`ocamltoplevel.cma` causes `Unbound value` error on REPL:

<img width="548" alt="2017-12-06 17 09 35" src="https://user-images.githubusercontent.com/6229475/33651194-4e149bd6-daa8-11e7-9115-8f1fd2d0014e.png">

This PR rejects loading `ocamltoplevel.cma` like:

<img width="729" alt="2017-12-06 17 02 03" src="https://user-images.githubusercontent.com/6229475/33651141-1d32795c-daa8-11e7-9327-1c59a873cea6.png">