### PR TITLE
Fix dependencies to unix, lwt.unix

### DIFF
--- a/jupyter/src/core/jbuild
+++ b/jupyter/src/core/jbuild
@@ -15,4 +15,4 @@
                 Version))
   (flags       ((:include ${ROOT}/config/ocaml_flags.sexp)))
   (preprocess  (pps (ppx_deriving_yojson)))
-  (libraries   (uuidm ppx_deriving_yojson.runtime))))
+  (libraries   (unix uuidm ppx_deriving_yojson.runtime))))

--- a/jupyter/src/log/jbuild
+++ b/jupyter/src/log/jbuild
@@ -6,4 +6,4 @@
   (modules     (Jupyter_log))
   (flags       ((:include ${ROOT}/config/ocaml_flags.sexp)))
   (preprocess  (pps (lwt.ppx)))
-  (libraries   (lwt))))
+  (libraries   (lwt lwt.unix))))


### PR DESCRIPTION
jbuilder 1.0+beta17 can build ocaml-jupyter 2.2.1, but jbuilder beta18 cannot do due to lack of dependencies in `jbuild` file, cf. https://github.com/ocaml/opam-repository/pull/11457#issuecomment-368722345. I don't know why beta17 can do, but I'm sure that it's a bug of ocaml-jupyter. ocaml-jupyter can build by beta18 after merging this PR.