### PR TITLE
Use correct prefix for merlin completion

### DIFF
--- a/jupyter/src/completor/merlin.ml
+++ b/jupyter/src/completor/merlin.ml
@@ -209,8 +209,8 @@ let complete ?(doc = false) ?(types = false) ~pos merlin code =
     | Some reply ->
       { reply with
         cmpl_start =
-          begin match String.rindex_from_opt prefix (prefix_length - 1) '.' with
-          | Some pos -> prefix_start + pos + 1
-          | None -> prefix_start
+          begin match String.rindex_from prefix (prefix_length - 1) '.' with
+            | pos -> prefix_start + pos + 1
+            | exception Not_found -> prefix_start
           end;
         cmpl_end = pos; }

--- a/jupyter/src/completor/merlin.ml
+++ b/jupyter/src/completor/merlin.ml
@@ -183,6 +183,13 @@ let rec rfind_prefix_start s = function
     | '0'..'9' | 'a'..'z' | 'A'..'Z' | '_' | '\'' | '`' | '.' -> rfind_prefix_start s (pos - 1)
     | _ -> pos
 
+let rec find_cmpl_end s pos =
+  if pos < String.length s then
+    match s.[pos] with
+    | '0'..'9' | 'a'..'z' | 'A'..'Z' | '_' | '\'' | '`' | '.' -> find_cmpl_end s (pos + 1)
+    | _ -> pos
+  else pos
+
 let complete ?(doc = false) ?(types = false) ~pos merlin code =
   let context = Buffer.contents merlin.context in
   let offset = String.length context in
@@ -213,4 +220,4 @@ let complete ?(doc = false) ?(types = false) ~pos merlin code =
             | pos -> prefix_start + pos + 1
             | exception Not_found -> prefix_start
           end;
-        cmpl_end = pos; }
+        cmpl_end = find_cmpl_end code pos; }

--- a/test/completor/test_merlin.ml
+++ b/test/completor/test_merlin.ml
@@ -123,10 +123,37 @@ let test_complete ctxt =
     } in
   let actual = complete merlin ~types:true code ~pos:15 in
   require expected actual ~msg:"at the last of identifier" ;
-  let actual = complete merlin ~types:true code ~pos:13 in
+  let expected = Merlin.{
+      cmpl_start = 13; cmpl_end = 15;
+      cmpl_candidates = [
+        { cmpl_name = "map"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "('a -> 'b) -> 'a list -> 'b list";
+          cmpl_doc = ""; };
+        { cmpl_name = "map2"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list";
+          cmpl_doc = ""; };
+        { cmpl_name = "mapi"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "(int -> 'a -> 'b) -> 'a list -> 'b list";
+          cmpl_doc = ""; };
+        { cmpl_name = "mem"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "'a -> 'a list -> bool";
+          cmpl_doc = ""; };
+        { cmpl_name = "mem_assoc"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "'a -> ('a * 'b) list -> bool";
+          cmpl_doc = ""; };
+        { cmpl_name = "mem_assq"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "'a -> ('a * 'b) list -> bool";
+          cmpl_doc = ""; };
+        { cmpl_name = "memq"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "'a -> 'a list -> bool";
+          cmpl_doc = ""; };
+        { cmpl_name = "merge"; cmpl_kind = CMPL_VALUE;
+          cmpl_type = "('a -> 'a -> int) -> 'a list -> 'a list -> 'a list";
+          cmpl_doc = ""; };
+      ];
+    } in
+  let actual = complete merlin ~types:true code ~pos:14 in
   require expected actual ~msg:"at the middle point of identifier" ;
-  let actual = complete merlin ~types:true code ~pos:8 in
-  require expected actual ~msg:"at the head of identifier" ;
   let code = "module M = Comp " in
   let expected = Merlin.{
       cmpl_start = 11; cmpl_end = 15;
@@ -135,7 +162,7 @@ let test_complete ctxt =
           cmpl_type = ""; cmpl_doc = ""; };
       ];
     } in
-  let actual = complete merlin code ~pos:11 in
+  let actual = complete merlin code ~pos:15 in
   require expected actual ~msg:"module" ;
   Merlin.add_context merlin "#load \"unix.cma\"" ;
   let code = "let _ = Unix.std " in
@@ -152,9 +179,9 @@ let test_complete ctxt =
     } in
   let actual = complete merlin code ~types:true ~pos:16 in
   require expected actual ~msg:"context" ;
-  let code = "let _ = Unix.EIN " in
+  let code = "let _ = Unix.EINP " in
   let expected = Merlin.{
-      cmpl_start = 13; cmpl_end = 16;
+      cmpl_start = 13; cmpl_end = 17;
       cmpl_candidates = [
         { cmpl_name = "EINPROGRESS"; cmpl_kind = CMPL_CONSTR;
           cmpl_type = "Unix.error"; cmpl_doc = ""; };
@@ -164,7 +191,7 @@ let test_complete ctxt =
           cmpl_type = "Unix.error"; cmpl_doc = ""; };
       ];
     } in
-  let actual = complete merlin code ~types:true ~pos:11 in
+  let actual = complete merlin code ~types:true ~pos:16 in
   require expected actual ~msg:"variant constructor"
 
 let suite =


### PR DESCRIPTION
The current approach of finding the prefix with `occurences` does not work. The correct prefix consists of everything that can be part of a qualified identifier (e.g. `String.le`), but the returned name is only the unqualified identifier (e.g. `length`).