### PR TITLE
Add ocp-indent configuration

### DIFF
--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,0 +1,12 @@
+base = 2
+type = 2
+in = 0
+with = 0
+match_clause = 2
+ppx_stritem_ext = 2
+max_indent = 4
+strict_with = never
+strict_else = always
+strict_comments = false
+align_ops = true
+align_params = auto


### PR DESCRIPTION
By adding the default configuration, all options from `$HOME/.ocp/ocp-indent.conf` or parent directories are reset.