### PR TITLE
Support multiple-version OCaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ OCaml Jupyter includes some sub-packages:
 [jupyter-archimedes]: https://akabe.github.io/ocaml-jupyter/api/jupyter-archimedes/
 [archimedes]:         http://archimedes.forge.ocamlcore.org/
 
+### Registration of multiple kernels
+
+You can add kernels of different versions of OCaml as different names like:
+
+```console
+$ opam switch create 4.06.0
+$ jupyter kernelspec install --name ocaml-jupyter-4.06.0 "$(opam config var share)/jupyter"
+$ opam switch create 4.07.1
+$ jupyter kernelspec install --name ocaml-jupyter-4.07.1 "$(opam config var share)/jupyter"
+```
+
+`OCaml 4.06.0` and `OCaml 4.07.1` are displayed on Jupyter.
+If you want to prepare kernels for each `opam-switch` environment,
+the following command is useful:
+
+```shell
+jupyter kernelspec install --name ocaml-jupyter-$(opam config var switch) "$(opam config var share)/jupyter"
+```
+
 ### Customize kernel parameters
 
 A kernelspec JSON is saved at the following path:
@@ -114,7 +133,8 @@ $ cat "$(opam config var share)/jupyter/kernel.json"
   "display_name": "OCaml 4.04.2",
   "language": "OCaml",
   "argv": [
-    "/home/USERNAME/.opam/4.04.2/bin/ocaml-jupyter-kernel",
+    "/bin/sh",
+    "/home/USERNAME/.opam/4.04.2/share/jupyter/kernel.sh",
     "--init",
     "/home/USERNAME/.ocamlinit",
     "--verbosity",

--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ Many Jupyter kernels for functional programming languages are available such as 
 | User-defined messages  | Yes           | No            |
 | Stdin                  | Yes           | No            |
 
-In addition, the installer of OCaml Jupyter automatically adds the kernel to Jupyter.
-
 Another OCaml kernel [simple_jucaml][simple_jucaml] seems too simple to use in practice.
 [jupyter-kernel][jupyter-kernel] is a library to write OCaml kernels (*not a kernel*), but OCaml Jupyter kernel does not use this library.
 

--- a/config/dune
+++ b/config/dune
@@ -33,11 +33,11 @@
 ;;
 
 (rule
- (targets kernel.json)
+ (targets kernel.json kernel.sh)
  (deps    kernelspec.exe)
  (action  (run %{deps})))
 
 (install
  (section share)
  (package jupyter)
- (files   kernel.json))
+ (files   kernel.json kernel.sh))

--- a/config/kernelspec.ml
+++ b/config/kernelspec.ml
@@ -1,4 +1,4 @@
-(** Generate kernel.json *)
+(** Generate kernel.sh and kernel.json *)
 
 open Format
 
@@ -9,14 +9,15 @@ type kernelspec =
     argv : string list;
   } [@@deriving to_yojson]
 
-let main ~output ~bindir ~home =
+let write_kernelspec_json ~output ~bindir ~sharedir ~switch ~home =
   let oc = open_out output in
-  let display_name = sprintf "OCaml %s" Sys.ocaml_version in
+  let display_name = sprintf "OCaml %s" switch in
   `Assoc [
     "display_name", `String display_name;
     "language", `String "OCaml";
     "argv", `List [
-      `String (Filename.concat bindir "ocaml-jupyter-kernel");
+      `String "/bin/sh";
+      `String (Filename.(concat sharedir (concat "jupyter" "kernel.sh")));
       `String "--init";
       `String (Filename.concat home ".ocamlinit");
       `String "--merlin";
@@ -30,6 +31,17 @@ let main ~output ~bindir ~home =
   |> Yojson.Safe.pretty_to_channel oc ;
   close_out oc
 
+let write_kernel_sh ~output ~bindir ~switch =
+  let oc = open_out output in
+  sprintf "\
+  #!/bin/sh\n\
+  \n\
+  eval `opam config env %S` && %S \"$@\"\n"
+    ("--switch=" ^ switch)
+    (Filename.concat bindir "ocaml-jupyter-kernel")
+  |> output_string oc ;
+  close_out oc
+
 let read_command cmd =
   let ic = Unix.open_process_in cmd in
   let rec aux acc = match input_line ic with
@@ -41,10 +53,15 @@ let read_command cmd =
   | Unix.WEXITED 0 -> lines
   | _ -> failwith cmd
 
+let read_command_line cmd =
+  match read_command cmd with
+  | [switch] -> switch
+  | msgs -> failwith (sprintf "[%s] %s@." cmd (String.concat "\n" msgs))
+
 let () =
   let home = Sys.getenv "HOME" in
-  let bindir = match read_command "opam config var bin" with
-    | [bindir] -> bindir
-    | msgs -> failwith (sprintf "[opam config var bin] %s@."
-                          (String.concat "\n" msgs)) in
-  main ~output:"kernel.json" ~bindir ~home
+  let switch = read_command_line "opam config var switch" in
+  let bindir = read_command_line "opam config var bin" in
+  let sharedir = read_command_line "opam config var share" in
+  write_kernel_sh ~output:"kernel.sh" ~bindir ~switch ;
+  write_kernelspec_json ~output:"kernel.json" ~bindir ~sharedir ~switch ~home


### PR DESCRIPTION
Kernels of different versions of OCaml can be registered, e.g.,

```console
$ jupyter kernelspec install --name ocaml-jupyter-4.05 /Users/a14180/.opam/4.05.0/share/jupyter
$ jupyter kernelspec install --name ocaml-jupyter-4.06 /Users/a14180/.opam/4.06.0/share/jupyter
```

but a kernel cannot be loaded dependently on the current environment by `opam config env`.
This problem is reported at issue #103 .

In the new version, `kernelspec.ml` outputs `kernel.sh`: it sets environment variables by  `opam config env --switch=XXX`  and calls `ocaml-jupyter-kernel` under the environment. `kernel.json` refers `kernel.sh` instead of `ocaml-jupyter-kernel` directly.