### PR TITLE
Support ocaml parameters

### DIFF
--- a/config/kernelspec.ml
+++ b/config/kernelspec.ml
@@ -18,7 +18,7 @@ let write_kernelspec_json ~output ~bindir ~sharedir ~switch ~home =
     "argv", `List [
       `String "/bin/sh";
       `String (Filename.(concat sharedir (concat "jupyter" "kernel.sh")));
-      `String "--init";
+      `String "-init";
       `String (Filename.concat home ".ocamlinit");
       `String "--merlin";
       `String (Filename.concat bindir "ocamlmerlin");

--- a/jupyter/bin/jupyter_args.ml
+++ b/jupyter/bin/jupyter_args.ml
@@ -41,22 +41,22 @@ let parse () =
   let specs = align [
       "--connection-file",
       Set_string connection_file,
-      "<file> connection information to Jupyter";
+      "<file> Connection information to Jupyter";
       "--init",
       String (fun s -> Clflags.init_file := Some s),
       "<file> An alias of -init"; (* for compatibility with ocaml-jupyter v2.3.5 or below *)
       "--merlin",
       Set_string merlin,
-      "<file> path of ocamlmerlin";
+      "<file> Path to ocamlmerlin";
       "--dot-merlin",
       Set_string dot_merlin,
-      "<file> path of .merlin";
+      "<file> Path to .merlin";
       "--verbosity",
       Symbol (["debug"; "info"; "warning"; "error"; "app"], Jupyter_log.set_level),
-      "set log level";
+      "Set log level";
       "--error-ctx",
       Set_int error_ctx_size,
-      "<num> the number of context lines in error messages";
+      "<num> The number of context lines in error messages";
     ] in
   Jupyter_repl.Caml_args.parse
     Format.err_formatter

--- a/jupyter/bin/jupyter_main.ml
+++ b/jupyter/bin/jupyter_main.ml
@@ -38,15 +38,14 @@ module Client =
 
 let () =
   Printexc.record_backtrace true ;
-  let () = Jupyter_args.parse () in
+  Jupyter_args.parse () ;
   (* Fork OCaml REPL before starting a server!
      A few Lwt_unix functions (such as Lwt_unix.getservbyname, getaddrinfo)
      sometimes never returns on a REPL due to use of Lwt at the caller side of
      Toploop (compiler-libs). *)
   let repl =
     Jupyter_repl.Process.create
-      ~preload:!Jupyter_args.preload_objs
-      ~init_file:!Jupyter_args.init_file
+      ?init_file:(Jupyter_repl.Caml_args.get_ocamlinit_path ())
       ~error_ctx_size:!Jupyter_args.error_ctx_size () in
   let completor =
     Jupyter_completor.Merlin.create

--- a/jupyter/src/repl/caml_args.cppo.ml
+++ b/jupyter/src/repl/caml_args.cppo.ml
@@ -1,0 +1,222 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Command-line parameters for OCaml REPL *)
+
+(* Only this file is published under GNU GPL v2.1, not MIT license.
+
+   The following code is written based on toplevel/topmain.ml in the official OCaml
+   compiler, distributed under the GNU Lesser General Public License version
+   2.1, with the special exception on linking
+   described in https://github.com/ocaml/ocaml/blob/trunk/LICENSE. *)
+
+(* Position of the first non expanded argument *)
+let first_nonexpanded_pos = ref 0
+
+let current = ref (!Arg.current)
+
+let argv = ref Sys.argv
+
+let preload_objects = ref ["stdlib.cma"]
+
+(* Test whether the option is part of a responsefile *)
+let is_expanded pos = pos < !first_nonexpanded_pos
+
+let expand_position pos len =
+  if pos < !first_nonexpanded_pos then
+    first_nonexpanded_pos := !first_nonexpanded_pos + len (* Shift the position *)
+  else
+    first_nonexpanded_pos :=  pos + len + 2 (* New last position *)
+
+let prepare ppf =
+  Toploop.set_paths ();
+  try
+    let res =
+      let objects =
+        List.rev (!preload_objects @ !Compenv.first_objfiles)
+      in
+      List.for_all (Topdirs.load_file ppf) objects
+    in
+    !Toploop.toplevel_startup_hook ();
+    res
+  with x ->
+  try Location.report_exception ppf x; false
+  with x ->
+    Format.fprintf ppf "Uncaught exception: %s\n" (Printexc.to_string x);
+    false
+
+(* If [name] is "", then the "file" is stdin treated as a script file. *)
+let file_argument name =
+  let ppf = Format.err_formatter in
+  if Filename.check_suffix name ".cmo" || Filename.check_suffix name ".cma"
+  then preload_objects := name :: !preload_objects
+  else if is_expanded !current then begin
+    (* Script files are not allowed in expand options because otherwise the
+       check in override arguments may fail since the new argv can be larger
+       than the original argv. *)
+    Printf.eprintf "For implementation reasons, the toplevel does not support\
+                   \ having script files (here %S) inside expanded arguments passed through the\
+                   \ -args{,0} command-line option.\n" name ;
+    exit 2
+  end else begin
+    let newargs =
+      Array.sub Sys.argv !Arg.current
+        (Array.length Sys.argv - !Arg.current)
+    in
+    Compenv.readenv ppf Compenv.Before_link;
+    if prepare ppf && Toploop.run_script ppf name newargs
+    then exit 0
+    else exit 2
+  end
+
+let print_version () =
+  Printf.printf "ocaml-jupyter kernel version %s (OCaml version %s)\n"
+    Jupyter.Version.version Sys.ocaml_version ;
+  exit 0
+
+let print_version_num () =
+  Printf.printf "%s\n" Jupyter.Version.version ;
+  exit 0
+
+let wrap_expand f s =
+  let start = !current in
+  let arr = f s in
+  expand_position start (Array.length arr);
+  arr
+
+let set r () = r := true
+let clear r () = r := false
+
+module Options = Main_args.Make_bytetop_options (struct
+    let _absname = set Location.absname
+    let _I dir =
+      let dir = Misc.expand_directory Config.standard_library dir in
+      Clflags.include_dirs := dir :: !Clflags.include_dirs
+    let _init s = Clflags.init_file := Some s
+    let _noinit = set Clflags.noinit
+    let _labels = clear Clflags.classic
+    let _alias_deps = clear Clflags.transparent_modules
+    let _no_alias_deps = set Clflags.transparent_modules
+    let _app_funct = set Clflags.applicative_functors
+    let _no_app_funct = clear Clflags.applicative_functors
+    let _noassert = set Clflags.noassert
+    let _nolabels = set Clflags.classic
+    let _noprompt = set Clflags.noprompt
+    let _nopromptcont = set Clflags.nopromptcont
+    let _nostdlib = set Clflags.no_std_include
+    let _open s = Clflags.open_modules := s :: !Clflags.open_modules
+    let _ppx s = Compenv.first_ppx := s :: !Compenv.first_ppx
+    let _principal = set Clflags.principal
+    let _no_principal = clear Clflags.principal
+    let _rectypes = set Clflags.recursive_types
+    let _no_rectypes = clear Clflags.recursive_types
+    let _safe_string = clear Clflags.unsafe_string
+    let _short_paths = clear Clflags.real_paths
+    let _stdin () = file_argument ""
+    let _strict_sequence = set Clflags.strict_sequence
+    let _no_strict_sequence = clear Clflags.strict_sequence
+    let _strict_formats = set Clflags.strict_formats
+    let _no_strict_formats = clear Clflags.strict_formats
+    let _unboxed_types = set Clflags.unboxed_types
+    let _no_unboxed_types = clear Clflags.unboxed_types
+    let _unsafe = set Clflags.fast
+    let _unsafe_string = set Clflags.unsafe_string
+    let _version () = print_version ()
+    let _vnum () = print_version_num ()
+    let _no_version = set Clflags.noversion
+    let _w s = Warnings.parse_options false s
+    let _warn_error s = Warnings.parse_options true s
+    let _warn_help = Warnings.help_warnings
+    let _dparsetree = set Clflags.dump_parsetree
+    let _dtypedtree = set Clflags.dump_typedtree
+    let _dsource = set Clflags.dump_source
+    let _drawlambda = set Clflags.dump_rawlambda
+    let _dlambda = set Clflags.dump_lambda
+    let _dflambda = set Clflags.dump_flambda
+    let _dinstr = set Clflags.dump_instr
+
+    let anonymous s = file_argument s
+
+#if OCAML_VERSION >= (4,05,0)
+    (* OCaml 4.05 or above *)
+    let _args = wrap_expand Arg.read_arg
+    let _args0 = wrap_expand Arg.read_arg0
+#endif
+
+#if OCAML_VERSION >= (4,06,0)
+    (* OCaml 4.06 or above *)
+    let _dtimings () = Clflags.profile_columns := [ `Time ]
+    let _dprofile () = Clflags.profile_columns := Profile.all_columns
+#else
+    (* OCaml 4.05 or below *)
+    let _plugin p = Compplugin.load p
+    let _dtimings = set Clflags.print_timings
+#endif
+
+#if OCAML_VERSION >= (4,07,0)
+    (* OCaml 4.07 or above *)
+    let _dno_unique_ids = clear Clflags.unique_ids
+    let _dunique_ids = set Clflags.unique_ids
+#endif
+
+end)
+
+#if OCAML_VERSION >= (4,05,0)
+
+(* OCaml 4.05 or above *)
+let parse ppf ~usage ~specs =
+  Compenv.readenv ppf Compenv.Before_args ;
+  let list = ref (specs @ Options.list) in
+  begin
+    try Arg.parse_and_expand_argv_dynamic current argv list file_argument usage
+    with
+    | Arg.Bad msg -> Printf.eprintf "%s" msg ; exit 2
+    | Arg.Help msg -> Printf.printf "%s" msg ; exit 0
+  end
+
+#else
+
+(* OCaml 4.04 *)
+let parse ppf ~usage ~specs =
+  Compenv.readenv ppf Compenv.Before_args ;
+  Arg.parse (specs @ Options.list) file_argument usage
+
+#endif
+
+let get_ocamlinit_path () =
+  let check_existence path =
+    if Sys.file_exists path then begin
+      Jupyter_log.debug (fun fmt -> fmt "Load init file %S." path) ;
+      Some path
+    end else begin
+      Jupyter_log.warn (fun fmt -> fmt "Init file not found: %S." path) ;
+      None
+    end
+  in
+  if !Clflags.noinit then None
+  else match !Clflags.init_file with
+    | Some path -> check_existence path
+    | None ->
+      if Sys.file_exists ".ocamlinit" then check_existence ".ocamlinit"
+      else
+        try check_existence @@ Filename.concat (Sys.getenv "HOME") ".ocamlinit"
+        with Not_found -> None

--- a/jupyter/src/repl/caml_args.mli
+++ b/jupyter/src/repl/caml_args.mli
@@ -20,14 +20,13 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
-(** Command-line arguments *)
+(** Command-line parameters for OCaml REPL *)
 
-val connection_file : string ref
+val prepare : Format.formatter -> bool
 
-val merlin : string ref
+val parse :
+  Format.formatter ->
+  usage:string ->
+  specs:(string * Arg.spec * string) list -> unit
 
-val dot_merlin : string ref
-
-val error_ctx_size : int ref
-
-val parse : unit -> unit
+val get_ocamlinit_path : unit -> string option

--- a/jupyter/src/repl/dune
+++ b/jupyter/src/repl/dune
@@ -5,6 +5,7 @@
  (modules     Jupyter_repl
               Process
               Evaluation
+              Caml_args
               Error
               Compat)
  (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
@@ -20,4 +21,9 @@
 (rule
  (targets compat.ml)
  (deps    compat.cppo.ml)
+ (action  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
+
+(rule
+ (targets caml_args.ml)
+ (deps    caml_args.cppo.ml)
  (action  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))

--- a/jupyter/src/repl/evaluation.mli
+++ b/jupyter/src/repl/evaluation.mli
@@ -23,11 +23,9 @@
 (** Top-level loop of OCaml code evaluation *)
 
 (** Globally initialize the OCaml REPL on the current process.
-    @param preload    [.cma] files to be loaded.
     @param preinit    function called before reading [.ocamlinit].
-    @param init_file  path to [.ocamlinit]. *)
+    @param init_file  path to [.ocamlinit].. *)
 val init :
-  ?preload:string list ->
   ?preinit:(unit -> unit) ->
   ?init_file:string ->
   unit -> unit

--- a/jupyter/src/repl/jupyter_repl.ml
+++ b/jupyter/src/repl/jupyter_repl.ml
@@ -26,4 +26,6 @@ module Process = Jupyter_repl__Process
 
 module Evaluation = Jupyter_repl__Evaluation
 
+module Caml_args = Jupyter_repl__Caml_args
+
 module Error = Jupyter_repl__Error

--- a/jupyter/src/repl/process.mli
+++ b/jupyter/src/repl/process.mli
@@ -25,15 +25,9 @@
 type t
 
 (** Creates an OCaml REPL process.
-
-    @param preload         a list of pre-loaded [.cma] files.
     @param init_file       read a given file instead of [.ocamlinit].
     @param error_ctx_size  the number of context lines in error messages. *)
-val create :
-  ?preload:string list ->
-  ?init_file:string ->
-  ?error_ctx_size:int ->
-  unit -> t
+val create : ?init_file:string -> ?error_ctx_size:int -> unit -> t
 
 val close : t -> unit Lwt.t
 

--- a/test/repl/eval_util.ml
+++ b/test/repl/eval_util.ml
@@ -73,7 +73,11 @@ let eval
     ?(post_exec = lwt_ignore)
     ?init_file ?(count = 0) code
   =
-  let repl = Process.create ?init_file () in
+  begin match init_file with
+    | None -> ()
+    | Some s -> Clflags.init_file := Some s
+  end ;
+  let repl = Process.create () in
   let strm = Process.stream repl in
   Lwt_main.run begin
     let%lwt _ = Process.eval ~ctx ~count repl code in


### PR DESCRIPTION
`ocaml-jupyter-kernel` supports command-line parameters of `ocaml` command (e.g., `-strict-sequence`). Parameters can be specified in `kernel.json`.