### PR TITLE
Fix compilation with newer library versions

### DIFF
--- a/jupyter-archimedes.opam
+++ b/jupyter-archimedes.opam
@@ -18,6 +18,6 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.0.0"}
   "jupyter"
-  "cairo2" {< "0.6"}
+  "cairo2" {>= "0.6"}
   "archimedes"
 ]

--- a/jupyter-archimedes/src/jupyter_archimedes.ml
+++ b/jupyter-archimedes/src/jupyter_archimedes.ml
@@ -33,7 +33,7 @@ module R = Archimedes.Backend.Register(struct
       let ctx : Cairo.context = Obj.magic b in
       let surf = Cairo.get_target ctx in
       let buf = Buffer.create 256 in
-      Cairo.PNG.write_to_stream ~output:(Buffer.add_string buf) surf ;
+      Cairo.PNG.write_to_stream surf (Buffer.add_string buf) ;
       close ~options b ;
       ignore (display ~base64:true "image/png" (Buffer.contents buf))
   end)

--- a/jupyter.opam
+++ b/jupyter.opam
@@ -19,15 +19,15 @@ depends: [
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}
-  "base64" {>= "2.1.2"}
+  "base64" {>= "3.1.0"}
   "lwt" {>= "4.0.0"}
   "lwt_ppx" {>= "1.0.0"}
   "logs" {>= "0.6.0"}
   "stdint" {>= "0.4.2"}
   "zmq" {>= "5.0.0"}
   "zmq-lwt" {>= "5.0.0"}
-  "yojson" {>= "1.3.3"}
-  "ppx_deriving_yojson" {>= "3.0"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yojson" {>= "3.3"}
   "cryptokit" {>= "1.12"}
   "dune" {build & >= "1.0.0"}
 ]

--- a/jupyter/src/comm/manager.ml
+++ b/jupyter/src/comm/manager.ml
@@ -32,9 +32,9 @@ type comm = string
 type receiver =
   {
     target_name : string;
-    recv_open : comm -> Yojson.Safe.json -> unit;
-    recv_msg : comm -> Yojson.Safe.json -> unit;
-    recv_close : comm -> Yojson.Safe.json -> unit;
+    recv_open : comm -> Yojson.Safe.t -> unit;
+    recv_msg : comm -> Yojson.Safe.t -> unit;
+    recv_close : comm -> Yojson.Safe.t -> unit;
   }
 
 module Target =

--- a/jupyter/src/comm/manager.mli
+++ b/jupyter/src/comm/manager.mli
@@ -78,9 +78,9 @@ sig
   val to_string : t -> string
 
   val create :
-    ?recv_open:(comm -> Yojson.Safe.json -> unit) ->
-    ?recv_msg:(comm -> Yojson.Safe.json -> unit) ->
-    ?recv_close:(comm -> Yojson.Safe.json -> unit) ->
+    ?recv_open:(comm -> Yojson.Safe.t -> unit) ->
+    ?recv_msg:(comm -> Yojson.Safe.t -> unit) ->
+    ?recv_close:(comm -> Yojson.Safe.t -> unit) ->
     string -> t
 
   val close : t -> unit
@@ -97,13 +97,13 @@ sig
   val comms : ?target_name:string -> unit -> (t * Target.t) list
 
   (** Send an open message to Jupyter. *)
-  val create : ?data:Yojson.Safe.json -> Target.t -> t
+  val create : ?data:Yojson.Safe.t -> Target.t -> t
 
   (** Send a close message to Jupyter. *)
-  val close : ?data:Yojson.Safe.json -> t -> unit
+  val close : ?data:Yojson.Safe.t -> t -> unit
 
   (** Send a message to Jupyter. *)
-  val send : t -> Yojson.Safe.json -> unit
+  val send : t -> Yojson.Safe.t -> unit
 
   (**/**)
 

--- a/jupyter/src/completor/merlin.ml
+++ b/jupyter/src/completor/merlin.ml
@@ -73,9 +73,9 @@ let call merlin command flags printer =
 
 type 'a merlin_reply =
   | RETURN of 'a [@name "return"]
-  | FAILURE of Yojson.Safe.json [@name "failure"]
-  | ERROR of Yojson.Safe.json [@name "error"]
-  | EXN of Yojson.Safe.json [@name "exception"]
+        | FAILURE of Yojson.Safe.json [@name "failure"]
+        | ERROR of Yojson.Safe.json [@name "error"]
+        | EXN of Yojson.Safe.json [@name "exception"]
 [@@deriving of_yojson]
 
 type 'a merlin_reply_body =
@@ -145,16 +145,16 @@ let abs_position code pos =
 
 type kind =
   | CMPL_VALUE [@name "Value"]
-  | CMPL_VARIANT [@name "Variant"]
-  | CMPL_CONSTR [@name "Constructor"]
-  | CMPL_LABEL [@name "Label"]
-  | CMPL_MODULE [@name "Module"]
-  | CMPL_SIG [@name "Signature"]
-  | CMPL_TYPE [@name "Type"]
-  | CMPL_METHOD [@name "Method"]
-  | CMPL_METHOD_CALL [@name "#"]
-  | CMPL_EXN [@name "Exn"]
-  | CMPL_CLASS [@name "Class"]
+      | CMPL_VARIANT [@name "Variant"]
+      | CMPL_CONSTR [@name "Constructor"]
+      | CMPL_LABEL [@name "Label"]
+      | CMPL_MODULE [@name "Module"]
+      | CMPL_SIG [@name "Signature"]
+      | CMPL_TYPE [@name "Type"]
+      | CMPL_METHOD [@name "Method"]
+      | CMPL_METHOD_CALL [@name "#"]
+      | CMPL_EXN [@name "Exn"]
+      | CMPL_CLASS [@name "Class"]
 [@@deriving yojson]
 
 type candidate =

--- a/jupyter/src/core/iopub.ml
+++ b/jupyter/src/core/iopub.ml
@@ -26,7 +26,7 @@
 
 type stream_name =
   | IOPUB_STDOUT [@name "stdout"]
-  | IOPUB_STDERR [@name "stderr"]
+      | IOPUB_STDERR [@name "stderr"]
 [@@deriving yojson { strict = false }]
 
 type stream =
@@ -70,8 +70,8 @@ type exec_result =
 
 type exec_status =
   | IOPUB_BUSY     [@name "busy"]
-  | IOPUB_IDLE     [@name "idle"]
-  | IOPUB_STARTING [@name "starting"]
+      | IOPUB_IDLE     [@name "idle"]
+      | IOPUB_STARTING [@name "starting"]
 [@@deriving yojson]
 
 type status =
@@ -103,16 +103,16 @@ type request = unit [@@deriving yojson]
 
 type reply =
   | IOPUB_STREAM of stream [@name "stream"]
-  | IOPUB_DISPLAY_DATA of display_data [@name "display_data"]
-  | IOPUB_UPDATE_DISPLAY_DATA of display_data [@name "update_display_data"]
-  | IOPUB_EXECUTE_INPUT of exec_input [@name "execute_input"]
-  | IOPUB_EXECUTE_RESULT of exec_result [@name "execute_result"]
-  | IOPUB_ERROR of error [@name "error"]
-  | IOPUB_STATUS of status [@name "status"]
-  | IOPUB_CLEAR_OUTPUT of clear_output [@name "clear_output"]
-  | IOPUB_COMM_OPEN of Comm.t [@name "comm_open"]
-  | IOPUB_COMM_MSG of Comm.t [@name "comm_msg"]
-  | IOPUB_COMM_CLOSE of Comm.t [@name "comm_close"]
+        | IOPUB_DISPLAY_DATA of display_data [@name "display_data"]
+        | IOPUB_UPDATE_DISPLAY_DATA of display_data [@name "update_display_data"]
+        | IOPUB_EXECUTE_INPUT of exec_input [@name "execute_input"]
+        | IOPUB_EXECUTE_RESULT of exec_result [@name "execute_result"]
+        | IOPUB_ERROR of error [@name "error"]
+        | IOPUB_STATUS of status [@name "status"]
+        | IOPUB_CLEAR_OUTPUT of clear_output [@name "clear_output"]
+        | IOPUB_COMM_OPEN of Comm.t [@name "comm_open"]
+        | IOPUB_COMM_MSG of Comm.t [@name "comm_msg"]
+        | IOPUB_COMM_CLOSE of Comm.t [@name "comm_close"]
 [@@deriving yojson]
 
 let stream ~name text =

--- a/jupyter/src/core/shell.ml
+++ b/jupyter/src/core/shell.ml
@@ -24,8 +24,8 @@
 
 type status =
   | SHELL_OK    [@name "ok"]
-  | SHELL_ERROR [@name "error"]
-  | SHELL_ABORT [@name "abort"]
+      | SHELL_ERROR [@name "error"]
+      | SHELL_ABORT [@name "abort"]
 [@@deriving yojson]
 
 (** {2 Execution requests and replies} *)
@@ -213,31 +213,31 @@ type shutdown =
 
 type request =
   | SHELL_KERNEL_INFO_REQ [@name "kernel_info_request"]
-  | SHELL_EXEC_REQ of exec_request [@name "execute_request"]
-  | SHELL_INSPECT_REQ of inspect_request [@name "inspect_request"]
-  | SHELL_COMPLETE_REQ of complete_request [@name "complete_request"]
-  | SHELL_HISTORY_REQ of history_request [@name "history_request"]
-  | SHELL_IS_COMPLETE_REQ of is_complete_request [@name "is_complete_request"]
-  | SHELL_CONNECT_REQ [@name "connect_request"]
-  | SHELL_COMM_INFO_REQ of comm_info_request [@name "comm_info_request"]
-  | SHELL_SHUTDOWN_REQ of shutdown [@name "shutdown_request"]
-  | SHELL_COMM_OPEN of Comm.t [@name "comm_open"]
-  | SHELL_COMM_MSG of Comm.t [@name "comm_msg"]
-  | SHELL_COMM_CLOSE of Comm.t [@name "comm_close"]
+      | SHELL_EXEC_REQ of exec_request [@name "execute_request"]
+        | SHELL_INSPECT_REQ of inspect_request [@name "inspect_request"]
+        | SHELL_COMPLETE_REQ of complete_request [@name "complete_request"]
+        | SHELL_HISTORY_REQ of history_request [@name "history_request"]
+        | SHELL_IS_COMPLETE_REQ of is_complete_request [@name "is_complete_request"]
+        | SHELL_CONNECT_REQ [@name "connect_request"]
+        | SHELL_COMM_INFO_REQ of comm_info_request [@name "comm_info_request"]
+        | SHELL_SHUTDOWN_REQ of shutdown [@name "shutdown_request"]
+        | SHELL_COMM_OPEN of Comm.t [@name "comm_open"]
+        | SHELL_COMM_MSG of Comm.t [@name "comm_msg"]
+        | SHELL_COMM_CLOSE of Comm.t [@name "comm_close"]
 [@@deriving yojson { strict = false }]
 
 (** {2 Reply} *)
 
 type reply =
   | SHELL_KERNEL_INFO_REP of kernel_info_reply [@name "kernel_info_reply"]
-  | SHELL_EXEC_REP of exec_reply [@name "execute_reply"]
-  | SHELL_INSPECT_REP of inspect_reply [@name "inspect_reply"]
-  | SHELL_COMPLETE_REP of complete_reply [@name "complete_reply"]
-  | SHELL_HISTORY_REP of history_reply [@name "history_reply"]
-  | SHELL_IS_COMPLETE_REP of is_complete_reply [@name "is_complete_reply"]
-  | SHELL_CONNECT_REP of connect_reply [@name "connect_reply"]
-  | SHELL_COMM_INFO_REP of comm_info_reply [@name "comm_info_reply"]
-  | SHELL_SHUTDOWN_REP of shutdown [@name "shutdown_reply"]
+        | SHELL_EXEC_REP of exec_reply [@name "execute_reply"]
+        | SHELL_INSPECT_REP of inspect_reply [@name "inspect_reply"]
+        | SHELL_COMPLETE_REP of complete_reply [@name "complete_reply"]
+        | SHELL_HISTORY_REP of history_reply [@name "history_reply"]
+        | SHELL_IS_COMPLETE_REP of is_complete_reply [@name "is_complete_reply"]
+        | SHELL_CONNECT_REP of connect_reply [@name "connect_reply"]
+        | SHELL_COMM_INFO_REP of comm_info_reply [@name "comm_info_reply"]
+        | SHELL_SHUTDOWN_REP of shutdown [@name "shutdown_reply"]
 [@@deriving yojson { strict = false }]
 
 let execute_reply ~count status =

--- a/jupyter/src/notebook/jupyter_notebook.ml
+++ b/jupyter/src/notebook/jupyter_notebook.ml
@@ -30,7 +30,7 @@ type display_id = string
 (** {2 Display} *)
 
 let display ?ctx ?display_id ?(metadata = `Assoc []) ?(base64 = false) mime data =
-  let data = if base64 then B64.encode data else data in
+  let data = if base64 then Base64.encode_exn data else data in
   let send content = Unsafe.send_iopub ?ctx content in
   match display_id with
   | None ->


### PR DESCRIPTION
I needed this to compile `ocaml-jupyter` on an up-to-date opam setup.