### PR TITLE
Fix build error on Mac OS X, Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ matrix:
       env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.07.1
     - os: linux
       env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.08.0+trunk
-    - os: osx
-      osx_image: xcode9
-      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.06.1
   allow_failures:
     - os: linux
       env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.08.0+trunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,21 +34,21 @@ env:
 matrix:
   include:
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.04.2
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.04.2
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.05.0
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.05.0
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.06.1 GIT_REMOTE_URL="https://akabe:$GITHUB_API_KEY@github.com/akabe/ocaml-jupyter"
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.06.1 GIT_REMOTE_URL="https://akabe:$GITHUB_API_KEY@github.com/akabe/ocaml-jupyter"
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.07.1
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.07.1
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.08.0+trunk
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.08.0+trunk
     - os: osx
       osx_image: xcode9
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.06.1
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.06.1
   allow_failures:
     - os: linux
-      env: OPAM_VERSION=2.0.0 OCAML_VERSION=4.08.0+trunk
+      env: OPAM_VERSION=2.0.3 OCAML_VERSION=4.08.0+trunk
 
 before_script:
   - eval "$(pyenv init -)"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ which will add the kernel to Jupyter. You can use `ocaml-jupyter` kernel by laun
 $ jupyter notebook
 ```
 
+If you get an error related to `archimedes.cairo` during installation of `jupyter-archimedes`,
+manually install `cairo2` before `archimedes`:
+
+```
+opam install "cairo2<0.6"
+opam reinstall archimedes
+opem install jupyter-archimedes
+```
+
 ### Development version
 
 ```console

--- a/jupyter-archimedes.opam
+++ b/jupyter-archimedes.opam
@@ -1,4 +1,6 @@
 opam-version: "2.0"
+synopsis: "A Jupyter-friendly 2D plotting library based on Archimedes"
+description: "This package added a Jupyter backend for Archimedes, a 2D plotting library written in OCaml. You can plot and embed figures on Jupyter."
 maintainer: [
   "Akinori ABE <aabe.65535@gmail.com>"
 ]

--- a/jupyter.opam
+++ b/jupyter.opam
@@ -1,4 +1,6 @@
 opam-version: "2.0"
+synopsis: "An OCaml kernel for Jupyter"
+description: "This provides an OCaml REPL with a great user interface such as markdown/HTML documentation, LaTeX formula by MathJax, and image embedding."
 maintainer: [
   "Akinori ABE <aabe.65535@gmail.com>"
 ]


### PR DESCRIPTION
OPAM 2.0.0 cannot install ocp-indent 1.7 due to a wrong checksum command on Mac OS X:

```console
$ opam install ocamlbuild=0.12.0 'ocp-indent>=1.7.0' -vv
+ /usr/local/bin/ocamlc "-vnum"
- 4.07.0
[NOTE] Package ocamlbuild is already installed (current version is 0.12.0).
The following actions will be performed:
  ↗ upgrade ocp-indent 1.6.1 to 1.7.0
Do you want to continue? [Y/n] y
...
+ /usr/bin/openssl "sha512" "/Users/a14180/.opam/4.06.0/.opam-switch/sources/ocp-indent.1.7.0/1.7.0.tar.gz"
- openssl:Error: 'sha512' is an invalid command.
...
```

This bug is fixed at OPAM 2.0.3.