### PR TITLE
Add some colab install notebook + readme instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ $ docker run -it -p 8888:8888 akabe/ocaml-jupyter-datascience
 
 [ocaml-jupyter-datascience]: https://github.com/akabe/docker-ocaml-jupyter-datascience
 
+## Running OCaml Jupyter on Google Colab
+
+OCaml Jupyter can be run on Google Colab. In order to do this you first have to run
+[this Python notebook](http://colab.research.google.com/github/akabe/ocaml-jupyter/blob/master/notebooks/install_ocaml_colab.ipynb)
+in your Colab instance. This will install the kernel and after that OCaml notebooks can be used on the same instance.
 
 ## Related work
 

--- a/notebooks/install_ocaml_colab.ipynb
+++ b/notebooks/install_ocaml_colab.ipynb
@@ -1,0 +1,133 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "install-ocaml-colab.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Q5Htcs1F8-DY",
+        "colab_type": "text"
+      },
+      "source": [
+        "This notebook lets you install an ocaml kernel for colab. In order to get started:\n",
+        "- Click on \"OPEN IN PLAYGROUND\".\n",
+        "- Run the cell below (this takes multiple minutes).\n",
+        "- Once the cell has run you can use some [ocaml notebook](https://colab.research.google.com/drive/107_RyCzQVL9gn7ZjeuUg5xMyT5xOK9em) on the same colab instance.\n",
+        "\n",
+        "This works by this first installing the necessary apt packages, then installing opam (the ocaml package manager) and building the ocaml compiler, and finally building and installing the [ocaml-jupyter kernel](https://github.com/akabe/ocaml-jupyter).\n",
+        "Note that when the instance gets disconnected, it gets resetted so you have to re-install the kernel.\n",
+        "\n",
+        "You can use the `use_cache` field in the form below in order to store the various binaries on your google drive the first time you run this, then re-installing should be a lot faster (this will require some google drive authentication).\n",
+        "\n",
+        "If your colab instance ends up in a bad state, Runtime > Reset all runtimes... should reset it.\n",
+        "\n",
+        "---\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "a16m43i1yUpd",
+        "colab_type": "code",
+        "cellView": "form",
+        "colab": {}
+      },
+      "source": [
+        "use_cache = \"none\" #@param [\"none\", \"opam-cache.tgz\"] {allow-input: true}\n",
+        "additional_apt_packages = \"none\" #@param [\"none\"] {allow-input: true}\n",
+        "additional_opam_packages = \"none\" #@param [\"none\"] {allow-input: true}\n",
+        "\n",
+        "import os\n",
+        "import subprocess\n",
+        "\n",
+        "if os.path.isdir('/root/.opam'):\n",
+        "  raise ValueError('opam directory already exists')\n",
+        "\n",
+        "def run_script(bash_script):\n",
+        "  print('Running the following commands:\\n%s' % bash_script)\n",
+        "  env = dict(os.environ)\n",
+        "  env['OCAML_INSTALL'] = bash_script\n",
+        "  process = subprocess.Popen(\n",
+        "    '/bin/bash -c \"$OCAML_INSTALL\"',\n",
+        "    shell=True,\n",
+        "    stdout=subprocess.PIPE,\n",
+        "    stderr=subprocess.PIPE,\n",
+        "    env=env)\n",
+        "  stdout, stderr = process.communicate()\n",
+        "  if stdout: print(stdout.decode())\n",
+        "  if stderr: print(stderr.decode())\n",
+        "  return_code = process.wait()\n",
+        "  if return_code:\n",
+        "    raise ValueError('subprocess failed %d' % return_code)\n",
+        "\n",
+        "bash_script = []\n",
+        "\n",
+        "apt_packages_ = [ 'libffi-dev', 'libgmp-dev', 'm4' ]\n",
+        "if additional_apt_packages != \"none\": apt_packages_ += additional_apt_packages.split(' ')\n",
+        "\n",
+        "opam_packages_ = [ 'base', 'jupyter' ]\n",
+        "if additional_opam_packages != \"none\": opam_packages_ += additional_opam_packages.split(' ')\n",
+        "\n",
+        "# Install the system packages.\n",
+        "run_script('apt install ' + ' '.join(apt_packages_))\n",
+        "\n",
+        "read_cache_ = None\n",
+        "write_cache_ = None\n",
+        "if 'use_cache' in dir() and use_cache is not None and use_cache:\n",
+        "  from google.colab import drive\n",
+        "  drive.mount('/content/drive')\n",
+        "  cache_file = '/content/drive/My Drive/' + use_cache\n",
+        "  if os.path.isfile(cache_file):\n",
+        "    read_cache_ = cache_file\n",
+        "  else:\n",
+        "    write_cache_ = cache_file\n",
+        "\n",
+        "# Install opam.\n",
+        "run_script(\n",
+        "  '(echo \"\" && yes Y) | (sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh))')\n",
+        "  \n",
+        "if read_cache_ is None:\n",
+        "  run_script('echo N | opam init --disable-sandboxing')\n",
+        "  \n",
+        "  # Install opam packages.\n",
+        "  run_script('opam install -y ' + ' '.join(opam_packages_))\n",
+        "  if write_cache_ is not None:\n",
+        "    run_script('(cd; tar -czf \"%s\" .opam)' % write_cache_)\n",
+        "else:\n",
+        "  run_script('(cd; tar -xzf \"%s\")' % read_cache_)\n",
+        "\n",
+        "run_script('jupyter kernelspec install --name ocaml-jupyter /root/.opam/default/share/jupyter')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EIbwAQ2b55bR",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Running this cell lists all the installed jupyter kernel.\n",
+        "# After running the previous cell, you should have an ocaml-jupyter kernel listed.\n",
+        "!jupyter-kernelspec list"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}

--- a/notebooks/install_ocaml_colab.ipynb
+++ b/notebooks/install_ocaml_colab.ipynb
@@ -86,7 +86,7 @@
         "\n",
         "read_cache_ = None\n",
         "write_cache_ = None\n",
-        "if 'use_cache' in dir() and use_cache is not None and use_cache:\n",
+        "if use_cache is not None and use_cache != 'none' and use_cache:\n",
         "  from google.colab import drive\n",
         "  drive.mount('/content/drive')\n",
         "  cache_file = '/content/drive/My Drive/' + use_cache\n",
@@ -109,6 +109,7 @@
         "else:\n",
         "  run_script('(cd; tar -xzf \"%s\")' % read_cache_)\n",
         "\n",
+        "run_script('echo \'#use "topfind";;\' >> /root/.ocamlinit')\n",
         "run_script('jupyter kernelspec install --name ocaml-jupyter /root/.opam/default/share/jupyter')"
       ],
       "execution_count": 0,


### PR DESCRIPTION
As per #121 here is a PR that adds the notebook and links to it from the readme.
There are a couple low hanging fruits that would probably improve this a bit (I haven't looked at them so the first two points are hopefully straightforward to fix - I may submit more PRs to help with these when I get a chance):
- Not sure why but `#use "topfind";;` is needed before the `#require` directives (this prevents your nice introduction notebook from working out of the box).
- Merlin doesn't seem to work.
- It would probably be nice to have a tutorial showing how to use this with free GPU instances, e.g. using [ocaml-torch](https://github.com/LaurentMazare/ocaml-torch) to train some deep vision model. I've been able to do this manually but haven't packaged things. PyTorch is already installed, the only trick is to set the `LIBTORCH` environment variable to `/usr/local/lib/python3.6/dist-packages/torch` before calling `opam install -y torch`.

