### PR TITLE
Block on lwt/async.

### DIFF
--- a/jupyter/src/repl/dune
+++ b/jupyter/src/repl/dune
@@ -5,6 +5,7 @@
  (modules     Jupyter_repl
               Process
               Evaluation
+              Lwt_async_rewrite
               Caml_args
               Error
               Compat)

--- a/jupyter/src/repl/evaluation.ml
+++ b/jupyter/src/repl/evaluation.ml
@@ -81,6 +81,7 @@ let iopub_interrupt () =
 let eval_phrase ~filename phrase =
   Compat.reset_fatal_warnings () ;
   let phrase' = Compat.preprocess_phrase ~filename phrase in (* apply PPX *)
+  let phrase' = Lwt_async_rewrite.rewrite phrase' in
   Env.reset_cache_toplevel () ;
   let is_ok = Toploop.execute_phrase true ppf phrase' in
   let message = Buffer.contents buffer in

--- a/jupyter/src/repl/lwt_async_rewrite.ml
+++ b/jupyter/src/repl/lwt_async_rewrite.ml
@@ -1,0 +1,155 @@
+(* This module defines some rewrite rules to automatically transform
+   top-level values of type [Lwt.t] or [Async.t] into some corresponding
+   blocking calls.
+   This way, a top-level evaluation of ['a Lwt.t] blocks and eventually
+   returns a ['a].
+*)
+let with_loc loc str = {
+  Location.txt = str;
+  Location.loc = loc;
+}
+
+(* A rule for rewriting a toplevel expression. *)
+type rewrite_rule = {
+  type_to_rewrite : Longident.t;
+  mutable path_to_rewrite : Path.t option;
+  required_values : Longident.t list;
+  (* Values that must exist and be persistent for the rule to apply. *)
+  rewrite : Location.t -> Parsetree.expression -> Parsetree.expression;
+  (* The rewrite function. *)
+  enabled : bool;
+  (* Whether the rule is enabled or not. *)
+}
+
+let longident_lwt_main_run = Longident.Ldot (Longident.Lident "Lwt_main", "run")
+let longident_async_thread_safe_block_on_async_exn =
+  Longident.parse "Async.Thread_safe.block_on_async_exn"
+
+let nolabel = Asttypes.Nolabel
+
+let rewrite_rules = [
+  (* Rewrite Lwt.t expressions to Lwt_main.run <expr> *)
+  {
+    type_to_rewrite = Longident.parse "Lwt.t";
+    path_to_rewrite = None;
+    required_values = [longident_lwt_main_run];
+    rewrite = (fun loc e ->
+      let open Ast_helper in
+      with_default_loc loc (fun () ->
+        Exp.apply (Exp.ident (with_loc loc longident_lwt_main_run)) [(nolabel, e)]
+      )
+    );
+    enabled = true;
+  };
+
+  (* Rewrite Async.Defered.t expressions to
+     Async.Thread_safe.block_on_async_exn (fun () -> <expr>). *)
+  {
+    type_to_rewrite = Longident.parse "Async.Deferred.t";
+    path_to_rewrite = None;
+    required_values = [longident_async_thread_safe_block_on_async_exn];
+    rewrite = (fun loc e ->
+      let open Ast_helper in
+      let punit = Pat.construct (with_loc loc (Longident.Lident "()")) None in
+      with_default_loc loc (fun () ->
+        Exp.apply
+          (Exp.ident (with_loc loc longident_async_thread_safe_block_on_async_exn))
+          [(nolabel, Exp.fun_ nolabel None punit e)]
+      )
+    );
+    enabled = true;
+  }
+]
+
+let lookup_type longident env =
+  let path = Env.lookup_type longident env in
+  (path, Env.find_type path env)
+
+let rule_path rule =
+  match rule.path_to_rewrite with
+  | Some _ as x -> x
+  | None ->
+    try
+      let env = !Toploop.toplevel_env in
+      let path =
+        match lookup_type rule.type_to_rewrite env with
+        | path, { Types.type_kind     = Types.Type_abstract
+                ; Types.type_private  = Asttypes.Public
+                ; Types.type_manifest = Some ty
+                ; _
+                } -> begin
+            match Ctype.expand_head env ty with
+            | { Types.desc = Types.Tconstr (path, _, _); _ } -> path
+            | _ -> path
+          end
+        | path, _ -> path
+      in
+      let opt = Some path in
+      rule.path_to_rewrite <- opt;
+      opt
+    with _ ->
+      None
+
+(* Returns whether the given path is persistent. *)
+let rec is_persistent_path = function
+  | Path.Pident id -> Ident.persistent id
+  | Path.Pdot (p, _, _) -> is_persistent_path p
+  | Path.Papply (_, p) -> is_persistent_path p
+
+(* Check that the given long identifier is present in the environment
+   and is persistent. *)
+let is_persistent_in_env longident =
+  try
+    is_persistent_path (fst (Env.lookup_value longident !Toploop.toplevel_env))
+  with Not_found ->
+    false
+
+let rule_matches rule path =
+  rule.enabled &&
+  (match rule_path rule with
+   | None -> false
+   | Some path' -> Path.same path path') &&
+  List.for_all is_persistent_in_env rule.required_values
+
+(* Returns whether the argument is a toplevel expression. *)
+let is_eval = function
+  | { Parsetree.pstr_desc = Parsetree.Pstr_eval _; _ } -> true
+  | _ -> false
+
+(* Returns the rewrite rule associated to a type, if any. *)
+let rule_of_type typ =
+  match (Ctype.expand_head !Toploop.toplevel_env typ).Types.desc with
+  | Types.Tconstr (path, _, _) -> begin
+      try
+        Some (List.find (fun rule -> rule_matches rule path) rewrite_rules)
+      with _ ->
+        None
+    end
+  | _ ->
+    None
+
+let rewrite_str_item pstr_item tstr_item =
+  match pstr_item, tstr_item.Typedtree.str_desc with
+    | ({ Parsetree.pstr_desc = Parsetree.Pstr_eval (e, _);
+         Parsetree.pstr_loc = loc },
+       Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _)) -> begin
+      match rule_of_type typ with
+        | Some rule ->
+          { Parsetree.pstr_desc = Parsetree.Pstr_eval (rule.rewrite loc e, []);
+            Parsetree.pstr_loc = loc }
+        | None ->
+          pstr_item
+    end
+    | _ ->
+      pstr_item
+
+let rewrite phrase =
+  match phrase with
+    | Parsetree.Ptop_def pstr ->
+      if List.exists is_eval pstr then
+        let tstr, _, _ = Typemod.type_structure !Toploop.toplevel_env pstr Location.none in
+        Parsetree.Ptop_def (List.map2 rewrite_str_item pstr tstr.Typedtree.str_items)
+      else
+        phrase
+    | Parsetree.Ptop_dir _ ->
+      phrase

--- a/jupyter/src/repl/lwt_async_rewrite.ml
+++ b/jupyter/src/repl/lwt_async_rewrite.ml
@@ -34,11 +34,11 @@ let rewrite_rules = [
     path_to_rewrite = None;
     required_values = [longident_lwt_main_run];
     rewrite = (fun loc e ->
-      let open Ast_helper in
-      with_default_loc loc (fun () ->
-        Exp.apply (Exp.ident (with_loc loc longident_lwt_main_run)) [(nolabel, e)]
-      )
-    );
+        let open Ast_helper in
+        with_default_loc loc (fun () ->
+            Exp.apply (Exp.ident (with_loc loc longident_lwt_main_run)) [(nolabel, e)]
+          )
+      );
     enabled = true;
   };
 
@@ -49,14 +49,14 @@ let rewrite_rules = [
     path_to_rewrite = None;
     required_values = [longident_async_thread_safe_block_on_async_exn];
     rewrite = (fun loc e ->
-      let open Ast_helper in
-      let punit = Pat.construct (with_loc loc (Longident.Lident "()")) None in
-      with_default_loc loc (fun () ->
-        Exp.apply
-          (Exp.ident (with_loc loc longident_async_thread_safe_block_on_async_exn))
-          [(nolabel, Exp.fun_ nolabel None punit e)]
-      )
-    );
+        let open Ast_helper in
+        let punit = Pat.construct (with_loc loc (Longident.Lident "()")) None in
+        with_default_loc loc (fun () ->
+            Exp.apply
+              (Exp.ident (with_loc loc longident_async_thread_safe_block_on_async_exn))
+              [(nolabel, Exp.fun_ nolabel None punit e)]
+          )
+      );
     enabled = true;
   }
 ]
@@ -130,26 +130,26 @@ let rule_of_type typ =
 
 let rewrite_str_item pstr_item tstr_item =
   match pstr_item, tstr_item.Typedtree.str_desc with
-    | ({ Parsetree.pstr_desc = Parsetree.Pstr_eval (e, _);
-         Parsetree.pstr_loc = loc },
-       Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _)) -> begin
+  | ({ Parsetree.pstr_desc = Parsetree.Pstr_eval (e, _);
+       Parsetree.pstr_loc = loc },
+     Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _)) -> begin
       match rule_of_type typ with
-        | Some rule ->
-          { Parsetree.pstr_desc = Parsetree.Pstr_eval (rule.rewrite loc e, []);
-            Parsetree.pstr_loc = loc }
-        | None ->
-          pstr_item
+      | Some rule ->
+        { Parsetree.pstr_desc = Parsetree.Pstr_eval (rule.rewrite loc e, []);
+          Parsetree.pstr_loc = loc }
+      | None ->
+        pstr_item
     end
-    | _ ->
-      pstr_item
+  | _ ->
+    pstr_item
 
 let rewrite phrase =
   match phrase with
-    | Parsetree.Ptop_def pstr ->
-      if List.exists is_eval pstr then
-        let tstr, _, _ = Typemod.type_structure !Toploop.toplevel_env pstr Location.none in
-        Parsetree.Ptop_def (List.map2 rewrite_str_item pstr tstr.Typedtree.str_items)
-      else
-        phrase
-    | Parsetree.Ptop_dir _ ->
+  | Parsetree.Ptop_def pstr ->
+    if List.exists is_eval pstr then
+      let tstr, _, _ = Typemod.type_structure !Toploop.toplevel_env pstr Location.none in
+      Parsetree.Ptop_def (List.map2 rewrite_str_item pstr tstr.Typedtree.str_items)
+    else
       phrase
+  | Parsetree.Ptop_dir _ ->
+    phrase

--- a/jupyter/src/repl/lwt_async_rewrite.mli
+++ b/jupyter/src/repl/lwt_async_rewrite.mli
@@ -1,0 +1,1 @@
+val rewrite : Parsetree.toplevel_phrase -> Parsetree.toplevel_phrase


### PR DESCRIPTION
As per #124 this PR adds the same hack as utop so that top level values of types [Lwt.t] and [Async.t] at top-level are evaluated in a blocking way (for lwt via [Lwt.run]).
Using this I could pretty-print the body from your cohttp example without any need for explicitly calling `Lwt.run`, e.g. using the following code.  `body` still has a type of `string option Lwt.t` but the top-level interprets it and prints it properly.

```ocaml
let query = "OCaml" (* Search query *);;
let body =
    let base_uri = Uri.of_string "http://api.duckduckgo.com/?format=json" in
    let uri = Uri.add_query_param base_uri ("q", [query]) in
    Cohttp_lwt_unix.Client.get uri >>= fun (resp, body) -> (* GET contents from a given uri *)
    assert (Cohttp.Response.status resp = `OK) ; (* Check HTTP response code *)
    Cohttp_lwt.Body.to_string body >|= fun body -> (* Receive contents *)
    Yojson.Safe.from_string body
    |> [%of_yojson: t]
    |> function
    | Result.Ok { definition = ""; abstract = ""; } -> None
    | Result.Ok { definition = ""; abstract; } -> Some abstract
    | Result.Ok { definition; abstract = ""; } -> Some definition
    | _ -> failwith "Oops!"
;;
body
```