### PR TITLE
Fix for ocaml 4.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ matrix:
     - os: linux
       env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.08.1
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0+trunk
+      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0
     - os: linux
       env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.10.0+trunk
   allow_failures:
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0+trunk
+      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0
     - os: linux
       env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.10.0+trunk
 

--- a/jupyter/src/repl/compat.cppo.ml
+++ b/jupyter/src/repl/compat.cppo.ml
@@ -28,7 +28,7 @@ let preprocess_phrase ~filename = function
   | Parsetree.Ptop_def structure ->
     structure
     |> Pparse.apply_rewriters_str ~restore:true ~tool_name:"ocaml"
-#if OCAML_VERSION >= (4,04,0)
+#if OCAML_VERSION >= (4,04,0) && OCAML_VERSION < (4,09,0)
     |> Pparse.ImplementationHooks.apply_hooks { Misc.sourcefile = filename }
 #endif
     |> fun structure' -> Parsetree.Ptop_def structure'

--- a/jupyter/src/repl/compat.cppo.ml
+++ b/jupyter/src/repl/compat.cppo.ml
@@ -33,6 +33,7 @@ let preprocess_phrase ~filename = function
 #endif
     |> fun structure' -> Parsetree.Ptop_def structure'
   | phrase -> phrase
+[@@ocaml.warning "-27"]
 
 let pp_print_error_message ppf msg =
 #if OCAML_VERSION >= (4,04,0)

--- a/test/completor/dune
+++ b/test/completor/dune
@@ -1,6 +1,6 @@
 (executables
  (names      test_completor)
- (preprocess (pps lwt_ppx ppx_deriving.show))
+ (preprocess (pps lwt_ppx ppx_deriving.show ppx_deriving_yojson))
  (libraries  jupyter
              jupyter_completor
              oUnit

--- a/test/kernel/dune
+++ b/test/kernel/dune
@@ -1,7 +1,7 @@
 (executables
  (names      test_kernel)
  (modes      byte)
- (preprocess (pps lwt_ppx ppx_deriving.show))
+ (preprocess (pps lwt_ppx ppx_deriving.show ppx_deriving_yojson))
  (libraries  jupyter
              jupyter_kernel
              oUnit

--- a/test/repl/dune
+++ b/test/repl/dune
@@ -2,7 +2,7 @@
  (names      test_evaluation
              test_process)
  (modes      byte)
- (preprocess (pps lwt_ppx ppx_deriving.show))
+ (preprocess (pps lwt_ppx ppx_deriving.show ppx_deriving_yojson))
  (libraries  jupyter
              jupyter_repl
              oUnit


### PR DESCRIPTION
Which dropped support for compiler hooks and plugins. Should resolve https://github.com/akabe/ocaml-jupyter/issues/136

Locally only one test fails due to improved error messages in 4.09.

Also `ppx_deriving_yojson` seems to be required for some of the tests to build with recent dune/ppx_deriving_yojson, so I have updated the dune files.