### PR TITLE
Fix Jupyter_comm.Stdin.read_line (fixes #129)

### DIFF
--- a/jupyter/src/comm/stdin.ml
+++ b/jupyter/src/comm/stdin.ml
@@ -41,4 +41,4 @@ let read_line_async ~recv ?(password = false) prompt =
 
 let read_line ?password prompt =
   read_line_async ~recv:Router.blocking_on_recv ?password prompt ;
-  input_line stdin
+  input_line Router.stdin


### PR DESCRIPTION
read_line should read from Router.stdin (pipe populated by Router) and not from Pervasives.stdin (which will be closed when the kernel starts)