### PR TITLE
OCaml 4.11 and cairo2 0.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,23 +28,26 @@ env:
     - PATH=$PATH:$OPAM_PREFIX/bin:$HOME/.local/bin
     - PYTHONUSERBASE=$HOME/.local
     - PYTHONVERSION=3.6.1
+    - OPAM_VERSION=2.0.7
 
 matrix:
   include:
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.04.2 ARCHIMEDES=1
+      env: OCAML_VERSION=4.04.2 ARCHIMEDES=1
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.05.0 ARCHIMEDES=1
+      env: OCAML_VERSION=4.05.0 ARCHIMEDES=1
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.06.1 ARCHIMEDES=1 GIT_REMOTE_URL="https://akabe:$GITHUB_API_KEY@github.com/akabe/ocaml-jupyter"
+      env: OCAML_VERSION=4.06.1 ARCHIMEDES=1 GIT_REMOTE_URL="https://akabe:$GITHUB_API_KEY@github.com/akabe/ocaml-jupyter"
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.07.1 ARCHIMEDES=1
+      env: OCAML_VERSION=4.07.1 ARCHIMEDES=1
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.08.1 ARCHIMEDES=1
+      env: OCAML_VERSION=4.08.1 ARCHIMEDES=1
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0
+      env: OCAML_VERSION=4.09.0
     - os: linux
-      env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.10.0
+      env: OCAML_VERSION=4.10.0
+    - os: linux
+      env: OCAML_VERSION=4.11.0+trunk
   # allow_failures:
   #   - os: linux
   #     env: OPAM_VERSION=2.0.4 OCAML_VERSION=4.09.0
@@ -66,7 +69,15 @@ before_script:
   - pyenv global $PYTHONVERSION
   - pip install ipython==5.4.1 jupyter
   # Install OPAM and packages required for CI
-  - curl -L https://gist.githubusercontent.com/akabe/24979afbf95c4cf4393f589cda997e1b/raw/install_opam.sh | sh -xeu
+  - |
+    if ! which opam; then
+      mkdir -p "$OPAM_PREFIX/bin"
+      curl "https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$(uname -m)-$(uname -s)" \
+       -Lo "$OPAM_PREFIX/bin/opam"
+      chmod 755 "$OPAM_PREFIX/bin/opam"
+      opam init -a -y --bare ${OPAM_INIT_FLAGS:-}
+      opam switch create "$OCAML_VERSION" --repositories=default,beta=git://github.com/ocaml/ocaml-beta-repository.git
+    fi
   - eval $(opam env)
   - opam install -y ocamlfind 'merlin>=3.0.0' 'ounit>=2.0.0'
   - opam remove -y jupyter # remove ocaml-jupyter package in cache (if it exists)

--- a/jupyter-archimedes.opam
+++ b/jupyter-archimedes.opam
@@ -18,8 +18,8 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.0.0"}
+  "dune" {>= "1.0.0"}
   "jupyter"
-  "cairo2" {< "0.6"}
+  "cairo2" {>= "0.6"}
   "archimedes"
 ]

--- a/jupyter-archimedes/src/jupyter_archimedes.ml
+++ b/jupyter-archimedes/src/jupyter_archimedes.ml
@@ -33,7 +33,7 @@ module R = Archimedes.Backend.Register(struct
       let ctx : Cairo.context = Obj.magic b in
       let surf = Cairo.get_target ctx in
       let buf = Buffer.create 256 in
-      Cairo.PNG.write_to_stream ~output:(Buffer.add_string buf) surf ;
+      Cairo.PNG.write_to_stream surf (Buffer.add_string buf) ;
       close ~options b ;
       ignore (display ~base64:true "image/png" (Buffer.contents buf))
   end)

--- a/jupyter/src/repl/caml_args.cppo.ml
+++ b/jupyter/src/repl/caml_args.cppo.ml
@@ -191,6 +191,11 @@ module Options = Main_args.Make_bytetop_options (struct
     let _nopervasives = set Clflags.nopervasives
     let _alert = Warnings.parse_alert_option
 #endif
+
+#if OCAML_VERSION >= (4,11,0)
+    let _dlocations = set Clflags.locations
+    let _dno_locations = clear Clflags.locations
+#endif
 end)
 
 #if OCAML_VERSION >= (4,05,0)

--- a/test/repl/test_evaluation.ml
+++ b/test/repl/test_evaluation.ml
@@ -165,7 +165,11 @@ let test__long_error_message ctxt =
 let test__exception ctxt =
   let status, actual = eval "failwith \"FAIL\"" in
   let msg =
-    if Sys.ocaml_version >= "4.10"
+    if Sys.ocaml_version >= "4.11"
+    then "\x1b[31mException: Failure \"FAIL\".\n\
+          Raised at Stdlib.failwith in file \"stdlib.ml\", line 29, characters 17-33\n\
+          Called from Toploop.load_lambda in file \"toplevel/toploop.ml\", line 212, characters 17-27\n\x1b[0m"
+    else if Sys.ocaml_version >= "4.10"
     then "\x1b[31mException: Failure \"FAIL\".\n\
           Raised at file \"stdlib.ml\", line 29, characters 22-33\n\
           Called from file \"toplevel/toploop.ml\", line 212, characters 17-27\n\x1b[0m"


### PR DESCRIPTION
Current jupyter does no compile with OCaml 4.11. This PR fixes it and also add support for cairo2 >= 0.6