### PR TITLE
invoke script to generate kernel specs within Colab notebook

### DIFF
--- a/notebooks/install_ocaml_colab.ipynb
+++ b/notebooks/install_ocaml_colab.ipynb
@@ -110,6 +110,7 @@
         "  run_script('(cd; tar -xzf \"%s\")' % read_cache_)\n",
         "\n",
         "run_script('echo \\'#use \"topfind\";;\\' >> /root/.ocamlinit')\n",
+        "run_script('/root/.opam/4.07.1/.opam-switch/sources/jupyter.2.7.2/config/ocaml-jupyter-opam-genspec')\n",
         "run_script('jupyter kernelspec install --name ocaml-jupyter /root/.opam/4.07.1/share/jupyter')"
       ],
       "execution_count": 0,

--- a/notebooks/install_ocaml_colab.ipynb
+++ b/notebooks/install_ocaml_colab.ipynb
@@ -78,7 +78,7 @@
         "apt_packages_ = [ 'libffi-dev', 'libgmp-dev', 'm4' ]\n",
         "if additional_apt_packages != \"none\": apt_packages_ += additional_apt_packages.split(' ')\n",
         "\n",
-        "opam_packages_ = [ 'base', 'jupyter' ]\n",
+        "opam_packages_ = [ 'base', 'jupyter=2.7.2' ]\n",
         "if additional_opam_packages != \"none\": opam_packages_ += additional_opam_packages.split(' ')\n",
         "\n",
         "# Install the system packages.\n",


### PR DESCRIPTION
Fixes `OSError: [Errno 2] No such file or directory: '/root/.opam/4.07.1/share/jupyter'` emitted when executing the kernel install step `jupyter kernelspec install --name ocaml-jupyter /root/.opam/4.07.1/share/jupyter` inside the Colab notebook.