### PR TITLE
Change README to link to introduction notebook since required packages for other notebooks are not installed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $ docker run -it -p 8888:8888 akabe/ocaml-jupyter-datascience
 
 OCaml Jupyter can be run on [Binder](https://www.mybinder.org).  Click
 the button to get started:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/edmcman/ocaml-jupyter-binder-environment/master?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fakabe%252Fdocker-ocaml-jupyter-datascience%26urlpath%3Dtree%252Fdocker-ocaml-jupyter-datascience%252Fnotebooks%26branch%3Dmaster)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/edmcman/ocaml-jupyter-binder-environment/master?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fakabe%252Fdocker-ocaml-jupyter-datascience%26urlpath%3Dtree%252Fdocker-ocaml-jupyter-datascience%252Fnotebooks%252Fintroduction.ipynb%26branch%3Dmaster)
 
 For more information, see this [repository](https://github.com/edmcman/ocaml-jupyter-binder-environment).
 


### PR DESCRIPTION
See https://github.com/edmcman/ocaml-jupyter-binder-environment/issues/1