### PR TITLE
Conform OPAM version ≥ 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $ cat "$(opam var share)/jupyter/kernel.json"
   "argv": [
     "/bin/sh",
     "-c",
-    "eval $(opam config env --switch=4.08.1) && /home/xxxx/.opam/4.08.1/bin/ocaml-jupyter-kernel \"$@\"",
+    "eval $(opam env --switch=4.08.1) && /home/xxxx/.opam/4.08.1/bin/ocaml-jupyter-kernel \"$@\"",
     "-init", "/home/xxxx/.ocamlinit",
     "--merlin", "/home/xxxx/.opam/4.08.1/bin/ocamlmerlin",
     "--verbosity", "app",

--- a/config/ocaml-jupyter-opam-genspec
+++ b/config/ocaml-jupyter-opam-genspec
@@ -1,8 +1,8 @@
 #!/bin/sh -eu
 
-OPAM_BINDIR="$(opam config var bin)"
-OPAM_SWITCH="$(opam config var switch)"
-OPAM_SHAREDIR="$(opam config var share)/jupyter"
+OPAM_BINDIR="$(opam var bin)"
+OPAM_SWITCH="$(opam var switch)"
+OPAM_SHAREDIR="$(opam var share)/jupyter"
 
 mkdir -p "$OPAM_SHAREDIR/"
 
@@ -13,7 +13,7 @@ cat <<EOF >"$OPAM_SHAREDIR/kernel.json"
   "argv": [
     "/bin/sh",
     "-c",
-    "eval \$(opam config env --switch=$OPAM_SWITCH --shell=sh) && $OPAM_BINDIR/ocaml-jupyter-kernel \"\$@\"",
+    "eval \$(opam env --switch=$OPAM_SWITCH --shell=sh) && $OPAM_BINDIR/ocaml-jupyter-kernel \"\$@\"",
     "ocaml-jupyter-kernel",
     "-init", "$HOME/.ocamlinit",
     "--merlin", "$OPAM_BINDIR/ocamlmerlin",


### PR DESCRIPTION
In  OPAM version ≥ 2.1, `opam config var` must be replaced by `opam var`.