### PR TITLE
Utility functions inspired by IPython magics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get install -y bash zsh python2 python3 ruby
           opam install . -y --deps-only --with-test
           opam install 'merlin>3.0.0' -y
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ OCaml Jupyter can be installed by [OPAM][opam] as follows:
 pip install jupyter
 opam install jupyter
 grep topfind ~/.ocamlinit || echo '#use "topfind";;' >> ~/.ocamlinit  # For using '#require' directive
+grep Topfind.log ~/.ocamlinit || echo 'Topfind.log:=ignore;;' >> ~/.ocamlinit  # Suppress logging of topfind (recommended but not necessary)
 ocaml-jupyter-opam-genspec
 jupyter kernelspec install [ --user ] --name "ocaml-jupyter-$(opam var switch)" "$(opam var share)/jupyter"
 ```

--- a/jupyter.opam
+++ b/jupyter.opam
@@ -30,6 +30,7 @@ depends: [
   "zmq-lwt" {>= "5.0.0"}
   "yojson" {>="1.6.0"}
   "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
   "cryptokit" {>= "1.12"}
   "dune" {>= "1.0.0"}
   "ounit2" {with-test & >= "2.0.0"}

--- a/notebooks/magics.ipynb
+++ b/notebooks/magics.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "hundred-appearance",
+   "metadata": {},
+   "source": [
+    "# Utility functions inspired by IPython magics\n",
+    "\n",
+    "[IPython magic](https://ipython.readthedocs.io/en/stable/interactive/magics.html) is special command available in IPython kernel.\n",
+    "The magic provides helpful functionality such as calling external commands (bash, ruby, etc.), benchmarking, capturing of stdout/stderr, and so on.\n",
+    "The syntax of the magics is different from the Python core language: they starts with `%` or `%%`, and arguments are written like `--param`.\n",
+    "\n",
+    "OCaml Jupyter 2.8.0+ supports several utility functions inspired by IPython magics.\n",
+    "Unlike IPython magics, the functions are implemented by the OCaml core language, not syntax extension.\n",
+    "You don't need to study new syntax, and distinguish cell magics and line magics.\n",
+    "The utility functions inherits convenience and flexibility of the OCaml language.\n",
+    "They are included in `jupyter.notebook` package. You can see [API documentation of jupyter.notebook](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/) for details.\n",
+    "\n",
+    "For example, you can measure execution time of a snippet by the cell magic `%%timeit` in IPython as follows.\n",
+    "\n",
+    "```python\n",
+    "%%timeit\n",
+    "2 ** 1000\n",
+    "# > 884 ns ± 15.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)\n",
+    "```\n",
+    "\n",
+    "In OCaml Jupyter, `Jupyter_notebook.Bench.timeit` has the same functionality as `%%timeit`:\n",
+    "\n",
+    "```ocaml\n",
+    "open Jupyter_notebook\n",
+    "Bench.timeit (fun () -> 2. ** 1000.)\n",
+    "(* > - : Jupyter_notebook.Bench.stat Jupyter_notebook.Bench.t =\n",
+    " * >     Jupyter_notebook.Bench.({\n",
+    " * >      b_rtime = 25.639 ns ± 3.523 ns; b_utime = 25.518 ns ± 3.486 ns;\n",
+    " * >      b_stime = 0.053 ns ± 0.037 ns; }) *)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "curious-reality",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+   ],
+   "source": [
+    "#require \"jupyter.notebook\" ;;\n",
+    "open Jupyter_notebook ;;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enclosed-resort",
+   "metadata": {},
+   "source": [
+    "## 1. Benchmark\n",
+    "\n",
+    "Benchmark functions are in `Jupyter_notebook.Bench`.\n",
+    "We provide `time` and `timeit` corresponding to `%%time` and `%%timeit`, respectively.\n",
+    "\n",
+    "[Bench.time](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/Bench/index.html#val-time) evaluates a function once, and reports time of the execution.\n",
+    "The first component of a return value is `f ()`, and the second is benchmark result:\n",
+    "\n",
+    "- `b_rtime` is real time\n",
+    "- `b_utime` is user time\n",
+    "- `b_stime` is sys time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "intended-neighborhood",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "- : float * float Jupyter_notebook.Bench.t =\n",
+       "(1.07150860718626732e+301, Jupyter_notebook.Bench.({\n",
+       "   b_rtime = 4.053 us; b_utime = 2.000 us; b_stime = 3.000 us; }))\n"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Bench.time (fun () -> 2. ** 1000.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "unauthorized-pasta",
+   "metadata": {},
+   "source": [
+    "[Bench.timeit](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/Bench/index.html#val-timeit) is very similar to `Bench.time`, but the former calls a function repeatedly, and calculates mean of execution time of them.\n",
+    "`timeit` is a little reliable then `time`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "descending-ancient",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Bench.stat Jupyter_notebook.Bench.t =\n",
+       "Jupyter_notebook.Bench.({\n",
+       "  b_rtime = 26.035 ns ± 3.516 ns; b_utime = 25.773 ns ± 3.352 ns;\n",
+       "  b_stime = 0.132 ns ± 0.081 ns; })\n"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Bench.timeit (fun () -> 2. ** 1000.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hearing-communist",
+   "metadata": {},
+   "source": [
+    "## 2. Subprocess\n",
+    "\n",
+    "### 2.1. Command bindings\n",
+    "\n",
+    "You can call commands and executable programs from OCaml Jupyter.\n",
+    "[Jupyter_notebook.Process](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/Process/index.html) contains easy-to-use bindings of some popular commands.\n",
+    "\n",
+    "For example, `ls` command corresponds to `Process.ls`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "monthly-eight",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Untitled.ipynb\n",
+      "datasets\n",
+      "install_ocaml_colab.ipynb\n",
+      "introduction.ipynb\n",
+      "utility_like_ipython_magic.ipynb\n",
+      "word_description_from_DuckDuckGoAPI.ipynb\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0; stdout = None;\n",
+       " stderr = None}\n"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Process.ls [\".\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "demonstrated-pathology",
+   "metadata": {},
+   "source": [
+    "`sh` is also available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "collective-alberta",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NOTE] It seems you have not updated your repositories for a while. Consider updating them with:\n",
+      "       opam update\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following actions will be performed:\n",
+      "  ∗ install conf-lapack 1      [required by lacaml]\n",
+      "  ∗ install conf-blas   1      [required by lacaml]\n",
+      "  ∗ install lacaml      11.0.8\n",
+      "===== ∗ 3 =====\n",
+      "\n",
+      "<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 \n",
+      "[lacaml.11.0.8] downloaded from cache at https://opam.ocaml.org/cache\n",
+      "\n",
+      "<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 \n",
+      "∗ installed conf-lapack.1\n",
+      "∗ installed conf-blas.1\n",
+      "∗ installed lacaml.11.0.8\n",
+      "Done.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0; stdout = None;\n",
+       " stderr = None}\n"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Process.sh \"opam install -y lacaml\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "northern-public",
+   "metadata": {},
+   "source": [
+    "The long string syntax `{| ... |}` in OCaml is useful for writing a program of several lines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "otherwise-wednesday",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Alice\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0; stdout = None;\n",
+       " stderr = None}\n"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Process.python3 {|\n",
+    "def greeting(name: str) -> str:\n",
+    "    return 'Hello ' + name\n",
+    "\n",
+    "print(greeting('Alice'))|}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tough-zoning",
+   "metadata": {},
+   "source": [
+    "### 2.2. Capturing stdout/stderr\n",
+    "\n",
+    "`capture_stdout` and `capture_stderr` options controls capturing of stdout and stderr in a subprocess.\n",
+    "You can obtain stdout of a command in a return value by passing `~capture_stdout:true`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "metallic-estimate",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0;\n",
+       " stdout = Some \"This text is printed in a shell script.\\n\"; stderr = None}\n"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Process.sh ~capture_stdout:true {|echo \"This text is printed in a shell script.\"|}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "occasional-second",
+   "metadata": {},
+   "source": [
+    "``~capture_stderr:`Yes`` or ``~capture_stderr:`Redirect_to_stdout`` also captures stderr of a subprocess.\n",
+    "\n",
+    "[Process.capture_in_process](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/Process/index.html#val-capture_in_process) captures stdout and stderr of arbitrary user functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "configured-karma",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0;\n",
+       " stdout = Some \"This text is printed in a function.\\n\"; stderr = None}\n"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Process.capture_in_process (fun () -> print_endline \"This text is printed in a function.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "strange-baseline",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "OCaml 4.13.0",
+   "language": "OCaml",
+   "name": "ocaml-jupyter-4.13.0"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-ocaml",
+   "file_extension": ".ml",
+   "mimetype": "text/x-ocaml",
+   "name": "OCaml",
+   "nbconverter_exporter": null,
+   "pygments_lexer": "OCaml",
+   "version": "4.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/word_description_from_DuckDuckGoAPI.ipynb
+++ b/notebooks/word_description_from_DuckDuckGoAPI.ipynb
@@ -12,6 +12,39 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#require \"jupyter.notebook\" ;;\n",
+    "open Jupyter_notebook ;;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "- : Jupyter_notebook.Process.t =\n",
+       "{Jupyter_notebook.Process.exit_status = Unix.WEXITED 0; stdout = None;\n",
+       " stderr = None}\n"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(* Install dependencies*)\n",
+    "Process.sh \"opam install -y cohttp cohttp-lwt-unix ppx_yojson_conv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
@@ -19,26 +52,25 @@
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-     ]
+     "text": []
     }
    ],
    "source": [
-    "#require \"cohttp,cohttp-lwt-unix,ppx_yojson_conv\" ;;"
+    "#require \"cohttp,cohttp-lwt-unix,ppx_yojson_conv\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "open Lwt.Infix ;;"
+    "open Lwt.Infix"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -49,7 +81,7 @@
        "val yojson_of_t : t -> Ppx_yojson_conv_lib.Yojson.Safe.t = <fun>\n"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -63,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -74,7 +106,7 @@
        "val query : string = \"OCaml\"\n"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -86,7 +118,7 @@
        "   \"OCaml is a general-purpose, multi-paradigm programming language which extends the Caml dialect of ML with object-oriented features. OCaml was created in 1996 by Xavier Leroy, Jérôme Vouillon, Damien Doligez, Didier Rémy, Ascánder Suárez, and others. The OCaml toolchain includes an interactive\"... (* string length 994; truncated *)\n"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,22 +140,13 @@
     "    | { definition; _ } -> Some definition\n",
     "  end"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "OCaml 4.12.0",
+   "display_name": "OCaml 4.13.0",
    "language": "OCaml",
-   "name": "ocaml-jupyter"
+   "name": "ocaml-jupyter-4.13.0"
   },
   "language_info": {
    "codemirror_mode": "text/x-ocaml",
@@ -132,7 +155,7 @@
    "name": "OCaml",
    "nbconverter_exporter": null,
    "pygments_lexer": "OCaml",
-   "version": "4.12.0"
+   "version": "4.13.0"
   }
  },
  "nbformat": 4,

--- a/src/notebook/bench.ml
+++ b/src/notebook/bench.ml
@@ -1,0 +1,117 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Benchmark functions *)
+
+open Format
+
+type 'a t =
+  {
+    b_rtime : 'a; (** Real time for the process *)
+    b_utime : 'a; (** User time for the process *)
+    b_stime : 'a; (** System time for the process *)
+  }
+
+type stat =
+  {
+    bs_mean : float; (** Mean of execution time of a run *)
+    bs_std : float; (** Standard deviation of execution time of a run *)
+  }
+
+let pp pp_a ppf x =
+  fprintf ppf
+    "Jupyter_notebook.Bench.({@;<0 2>@[b_rtime = %a;@ b_utime = %a;@ b_stime = %a;@ @]})"
+    pp_a x.b_rtime pp_a x.b_utime pp_a x.b_stime
+
+let pp_timedelta ppf x =
+  if x < 1e-6 then fprintf ppf "%.3f ns" (x *. 1e9)
+  else if x < 1e-3 then fprintf ppf "%.3f us" (x *. 1e6)
+  else if x < 1.0 then fprintf ppf "%.3f ms" (x *. 1e3)
+  else if x < 60.0 then fprintf ppf "%.3f s" x
+  else begin
+    let x, d = Float.modf (x /. 86400.0) in
+    let x, h = Float.modf (x *. 24.0) in
+    let s, m = Float.modf (x *. 60.0) in
+    if d > 0.0 then fprintf ppf "%.0f days " d ;
+    fprintf ppf "%.0f:%02.0f:%02.0f" h m s
+  end
+
+let pp_float_t = pp pp_timedelta
+
+let pp_stat ppf x =
+  fprintf ppf "%a ± %a" pp_timedelta x.bs_mean pp_timedelta x.bs_std
+
+let time f =
+  let rt0 = Unix.gettimeofday () in
+  let tt0 = Unix.times () in
+  let y = f () in
+  let rt1 = Unix.gettimeofday () in
+  let tt1 = Unix.times () in
+  let res = {
+    b_rtime = rt1 -. rt0;
+    b_utime = tt1.Unix.tms_utime -. tt0.Unix.tms_utime;
+    b_stime = tt1.Unix.tms_stime -. tt0.Unix.tms_stime;
+  } in
+  (y, res)
+
+let stat ~f xs =
+  let n = float_of_int (List.length xs) in
+  let mean = List.fold_left (fun acc x -> acc +. f x) 0.0 xs /. n in
+  let var =
+    List.fold_left
+      (fun acc x -> let y = f x -. mean in acc +. y *. y)
+      0.0 xs /. n in
+  {
+    bs_mean = mean;
+    bs_std = sqrt var;
+  }
+
+let timeit
+    ?(runs = 5)
+    ?(loops_per_run = 1000000)
+    ?(before_run = fun () -> ())
+    ?(after_run = fun () -> ())
+    f
+  =
+  let lpr = float_of_int loops_per_run in
+  let loop () =
+    before_run () ;
+    let rt0 = Unix.gettimeofday () in
+    let tt0 = Unix.times () in
+    for _ = 1 to loops_per_run do
+      ignore (f ()) ;
+    done ;
+    let rt1 = Unix.gettimeofday () in
+    let tt1 = Unix.times () in
+    after_run () ;
+    {
+      b_rtime = (rt1 -. rt0) /. lpr;
+      b_utime = (tt1.Unix.tms_utime -. tt0.Unix.tms_utime) /. lpr;
+      b_stime = (tt1.Unix.tms_stime -. tt0.Unix.tms_stime) /. lpr;
+    }
+  in
+  let ts = List.init runs (fun _ -> loop ()) in
+  {
+    b_rtime = stat ~f:(fun t -> t.b_rtime) ts;
+    b_utime = stat ~f:(fun t -> t.b_utime) ts;
+    b_stime = stat ~f:(fun t -> t.b_stime) ts;
+  }

--- a/src/notebook/bench.mli
+++ b/src/notebook/bench.mli
@@ -1,0 +1,101 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Benchmark functions *)
+
+(** {2 Types} *)
+
+(** The type of execution time of functions or code snippets.
+
+    ['a] is [float] or [stat].
+
+    @since 2.8.0 *)
+type 'a t =
+  {
+    b_rtime : 'a; (** Real time for the process *)
+    b_utime : 'a; (** User time for the process *)
+    b_stime : 'a; (** System time for the process *)
+  }
+
+(** The type of summary results of repeated measurement of execution time.
+
+    @since 2.8.0 *)
+type stat =
+  {
+    bs_mean : float; (** Mean of execution time per a loop *)
+    bs_std : float; (** Standard deviation of execution time per a loop *)
+  }
+
+(** {2 Benchmark} *)
+
+(** [time f] measures execution time of a function [f].
+
+    @return a pair of [f ()] and a result of benchmark.
+    @since 2.8.0 *)
+val time : (unit -> 'a) -> ('a * float t)
+
+(** [timeit ?runs ?loops_per_run ?before_run ?after_run f]
+    repeatedly executes a function [f], and measures the mean and
+    the standard deviation of each execution time of [f ()].
+
+    {[for i = 1 to runs do
+        before_run () ;
+        (* --- start measurement of execution time of each run --- *)
+        for _ = 1 to loops_per_run do
+          ignore (f ()) ;
+        done ;
+        (* --- finish measurement --- *)
+        after_run () ;
+      done]}
+
+    [timeit] is inspired by {{:https://docs.python.org/3/library/timeit.html}timeit}
+    package in Python. The parameter [loops_per_run], [before_run] are named as
+    [number], [setup] respectively in Python.
+
+    @param runs  the number of running (default = 5)
+    @param loops_per_run  the number of loops per each run (default = 1,000,000)
+    @param before_run  function once called before each run.
+    @param after_run  function once called after each run.
+    @return  summary of measurement.
+    @since 2.8.0  *)
+val timeit :
+  ?runs:int ->
+  ?loops_per_run:int ->
+  ?before_run:(unit -> unit) ->
+  ?after_run:(unit -> unit) ->
+  (unit -> 'a) -> stat t
+
+(** {2 Pretty printers} *)
+
+(** @since 2.8.0 *)
+val pp :
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter -> 'a t -> unit
+
+(** @since 2.8.0 *)
+val pp_float_t : Format.formatter -> float t -> unit
+
+(** @since 2.8.0 *)
+val pp_timedelta : Format.formatter -> float -> unit
+
+(** @since 2.8.0 *)
+val pp_stat : Format.formatter -> stat -> unit

--- a/src/notebook/dune
+++ b/src/notebook/dune
@@ -2,11 +2,14 @@
  (name        jupyter_notebook)
  (public_name jupyter.notebook)
  (synopsis    "A library for Jupyter notebooks")
+ (preprocess  (pps ppx_yojson_conv ppx_deriving.show))
  (modes       byte)
  (modules     Jupyter_notebook
+              Bench
+              Process
+              Eval
               Unsafe)
  (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
- (preprocess  (pps ppx_yojson_conv))
  (libraries   jupyter
               uuidm
               base64

--- a/src/notebook/eval.ml
+++ b/src/notebook/eval.ml
@@ -1,0 +1,44 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Evaluation of OCaml code *)
+
+let eval code =
+  Lexing.from_string code
+  |> !Toploop.parse_toplevel_phrase
+  |> Toploop.execute_phrase false Format.err_formatter
+  |> ignore
+
+module _ = Bench
+
+let printers =
+  [
+    "Jupyter_notebook.Bench.pp";
+    "Jupyter_notebook.Bench.pp_stat";
+    "Jupyter_notebook.Bench.pp_float_t";
+  ]
+
+let () =
+  printers
+  |> List.iter (fun printer ->
+      Format.sprintf "#install_printer %s ;;" printer
+      |> eval)

--- a/src/notebook/eval.mli
+++ b/src/notebook/eval.mli
@@ -1,0 +1,27 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Evaluation of OCaml code *)
+
+(** [eval code] executes a given OCaml code in the toploop.
+    @since 2.8.0 *)
+val eval : string -> unit

--- a/src/notebook/jupyter_notebook.ml
+++ b/src/notebook/jupyter_notebook.ml
@@ -82,3 +82,11 @@ let display_formatter ?ctx ?display_id ?metadata ?base64 mime =
   let data = Buffer.contents formatter_buf in
   Buffer.clear formatter_buf ;
   display ?ctx ?display_id ?metadata ?base64 mime data
+
+(** {2 Utilities} *)
+
+module Bench = Jupyter_notebook__Bench
+
+module Process = Jupyter_notebook__Process
+
+module Eval = Jupyter_notebook__Eval

--- a/src/notebook/jupyter_notebook.mli
+++ b/src/notebook/jupyter_notebook.mli
@@ -90,3 +90,11 @@ val display_formatter :
   ?metadata:Yojson.Safe.t ->
   ?base64:bool ->
   string -> display_id
+
+(** {2 Utilities} *)
+
+module Bench = Jupyter_notebook__Bench
+
+module Process = Jupyter_notebook__Process
+
+module Eval = Jupyter_notebook__Eval

--- a/src/notebook/process.ml
+++ b/src/notebook/process.ml
@@ -1,0 +1,230 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Operations on subprocesses *)
+
+type process_status = Unix.process_status =
+  | WEXITED of int
+  | WSIGNALED of int
+  | WSTOPPED of int
+[@@deriving show]
+
+type t =
+  {
+    exit_status : process_status;
+    stdout : string option;
+    stderr : string option;
+  }
+[@@deriving show]
+
+type capture_stderr_type =
+  [
+    | `No
+    | `Yes
+    | `Redirect_to_stdout
+  ]
+
+exception Execution_failure of t
+
+let () = Printexc.register_printer (function
+    | Execution_failure r ->
+      Some (Format.sprintf "Execution_failure(%s)" ([%show: t] r))
+    | _ -> None)
+
+(** {2 Capturing} *)
+
+let run_in_process
+    ?(capture_stdin = false)
+    ?(capture_stdout = false)
+    ?(capture_stderr = `No)
+    f
+  =
+  let stdin_r, stdin_w = Unix.pipe () in
+  let stdout_r, stdout_w = Unix.pipe () in
+  let stderr_r, stderr_w = Unix.pipe () in
+  match Unix.fork () with
+  | 0 -> (* in a child process *)
+    Unix.close stdin_w ;
+    Unix.close stdout_r ;
+    Unix.close stderr_r ;
+    if capture_stdin then Unix.dup2 stdin_r Unix.stdin ;
+    if capture_stdout || capture_stderr = `Redirect_to_stdout then Unix.dup2 stdout_w Unix.stdout ;
+    begin
+      match capture_stderr with
+      | `No -> ()
+      | `Yes -> Unix.dup2 stderr_w Unix.stderr
+      | `Redirect_to_stdout ->
+        Unix.dup2 Unix.stdout Unix.stderr  ;
+        Unix.close Unix.stdout
+    end ;
+    Unix.close stdin_r ;
+    Unix.close stdout_w ;
+    Unix.close stderr_w ;
+    ignore (f ()) ;
+    exit 0
+  | pid -> (* in the parent process *)
+    Unix.close stdin_r ;
+    Unix.close stdout_w ;
+    Unix.close stderr_w ;
+    (pid, stdin_w, stdout_r, stderr_r)
+
+let is_readable fd timeout =
+  let l, _, _ = Unix.select [fd] [] [] timeout in
+  l <> []
+
+let try_read ~interval fd buffer bytes =
+  let rec aux () =
+    if is_readable fd interval then begin
+      let k = Unix.read fd bytes 0 (Bytes.length bytes) in
+      if k > 0 then begin
+        Buffer.add_subbytes buffer bytes 0 k ;
+        aux ()
+      end
+    end in
+  try aux ()
+  with Unix.Unix_error (Unix.EBADF, _, _) -> () (* fd is already closed. *)
+
+let buffer_size = 128
+
+let capture_and_wait
+    ?(check = true)
+    ?(interval = 0.1)
+    ~capture_stdout
+    ~capture_stderr
+    pid fin fout ferr
+  =
+  let bytes = Bytes.create buffer_size in
+  let out_buf = Buffer.create buffer_size in
+  let err_buf = Buffer.create buffer_size in
+  let rec loop () =
+    (* First, check the current status of a process. *)
+    let pid', status = Unix.(waitpid [WNOHANG; WUNTRACED] pid) in
+    if pid' <> 0 then status (* terminate the loop *)
+    else begin
+      (* Second, try to read from pipes. *)
+      try_read ~interval fout out_buf bytes ;
+      try_read ~interval ferr err_buf bytes ;
+      loop () (* continue the loop *)
+    end
+  in
+  let status = loop () in
+  (* Try to read remaining data after termination of a process. *)
+  try_read ~interval fout out_buf bytes ;
+  try_read ~interval ferr err_buf bytes ;
+  (* Close file descriptors of pipes. *)
+  Unix.close fin ;
+  Unix.close fout ;
+  Unix.close ferr ;
+  (* Construct an execution result of a process. *)
+  let using_out = capture_stdout || capture_stderr = `Redirect_to_stdout in
+  let using_err = capture_stderr = `Yes in
+  let result = {
+    exit_status = status;
+    stdout = if using_out then Some (Buffer.contents out_buf) else None;
+    stderr = if using_err then Some (Buffer.contents err_buf) else None;
+  } in
+  (* Check a status if necessary. *)
+  if check && status <> Unix.WEXITED 0 then raise (Execution_failure result) ;
+  result
+
+let capture_in_process
+    ?check
+    ?(capture_stdout = true)
+    ?(capture_stderr = `No)
+    ?interval
+    f
+  =
+  let pid, fin, fout, ferr =
+    run_in_process ~capture_stdin:true ~capture_stdout ~capture_stderr f in
+  capture_and_wait
+    ?check ~capture_stdout ~capture_stderr ?interval pid fin fout ferr
+
+(** {2 Command bindings} *)
+
+let system
+    ?check
+    ?(capture_stdout = false)
+    ?(capture_stderr = `No)
+    ?interval
+    prog args
+  =
+  let pid, fin, fout, ferr =
+    run_in_process ~capture_stdin:true ~capture_stdout ~capture_stderr
+      (fun () -> Unix.execvp prog (Array.of_list args)) in
+  capture_and_wait
+    ?check ~capture_stdout ~capture_stderr ?interval pid fin fout ferr
+
+let pwd = Unix.getcwd
+
+let cd = Unix.chdir
+
+let ls ?check ?capture_stdout ?capture_stderr ?interval ?(args = []) paths =
+  system ?check ?capture_stdout ?capture_stderr ?interval
+    "ls" ("ls" :: args @ ("--" :: paths))
+
+let rm ?check ?capture_stdout ?capture_stderr ?interval ?(args = []) paths =
+  system ?check ?capture_stdout ?capture_stderr ?interval
+    "rm" ("rm" :: args @ ("--" :: paths))
+
+let cp ?check ?capture_stdout ?capture_stderr ?interval ?(args = []) src_path dest_path =
+  system ?check ?capture_stdout ?capture_stderr ?interval
+    "cp" ("cp" :: args @ ["--"; src_path; dest_path])
+
+let mv ?check ?capture_stdout ?capture_stderr ?interval ?(args = []) src_path dest_path =
+  system ?check ?capture_stdout ?capture_stderr ?interval
+    "mv" ("mv" :: args @ ["--"; src_path; dest_path])
+
+let eval_script
+    ?check ?capture_stdout ?capture_stderr ?interval
+    ?(args = []) ~opt prog script
+  =
+  system
+    ?check ?capture_stdout ?capture_stderr ?interval
+    prog (prog :: opt :: script :: args)
+
+let sh ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-c" "sh" script
+
+let zsh ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-c" "zsh" script
+
+let bash ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-c" "bash" script
+
+let python2 ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-c" "python2" script
+
+let python3 ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-c" "python3" script
+
+let ruby ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-e" "ruby" script
+
+let perl ?check ?capture_stdout ?capture_stderr ?interval ?args script =
+  eval_script ?check ?capture_stdout ?capture_stderr ?interval
+    ?args ~opt:"-e" "perl" script

--- a/src/notebook/process.mli
+++ b/src/notebook/process.mli
@@ -1,0 +1,247 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Operations on subprocesses *)
+
+type process_status = Unix.process_status =
+  | WEXITED of int
+  | WSIGNALED of int
+  | WSTOPPED of int
+[@@deriving show]
+
+(** The type of execution results of subprocesses. *)
+type t =
+  {
+    exit_status : Unix.process_status;
+    stdout : string option;
+    stderr : string option;
+  }
+[@@deriving show]
+
+type capture_stderr_type =
+  [
+    | `No
+    | `Yes
+    | `Redirect_to_stdout
+  ]
+
+exception Execution_failure of t
+
+(** {2 Command bindings} *)
+
+(** [system prog args] is a rich version of [Unix.system] and [Sys.command] in
+    the standard library of OCaml.
+
+    Example:
+    {[system "ocaml" ["ocaml"; "-vnum"]]}
+
+    @param check           raises an execption when a process fails (default = [true])
+    @param capture_stdout  default = [true]
+    @param capture_stderr  default = [`No]
+    @param interval        timeout of [Unix.select] for waiting IO (default = [0.1] seconds)
+    @param prog            The path or the name of an executable file. If not a path,
+                           the environment variable [$PATH] is used for finding the file.
+    @param args            The list of arguments given to a command.
+
+    @return an execution result of a subprocess.
+
+    @since 2.8.0 *)
+val system :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  string -> string list -> t
+
+(** [pwd ()] returns a path to the current directory.
+
+    This is an alias of [Unix.getcwd].
+
+    @since 2.8.0 *)
+val pwd : unit -> string
+
+(** [cd path] changes the current directory.
+
+    This is an alias of [Unix.chdir].
+
+    @since 2.8.0 *)
+val cd : string -> unit
+
+(** [ls ?check ?capture_stdout ?capture_stderr ?interval ?args paths]
+    shows a list of files in [paths].
+
+    @since 2.8.0 *)
+val ls :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list ->
+  string list -> t
+
+(** [rm ?check ?capture_stdout ?capture_stderr ?interval ?args paths]
+    removes files in [paths].
+
+    @since 2.8.0 *)
+val rm :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list ->
+  string list -> t
+
+(** [cp ?check ?capture_stdout ?capture_stderr ?interval ?args src_path dest_path]
+    copys a file or a directory from [src_path] into [dest_path].
+
+    @since 2.8.0 *)
+val cp :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list ->
+  string -> string -> t
+
+(** [mv ?check ?capture_stdout ?capture_stderr ?interval ?args src_path dest_path]
+    moves a file or a directory from [src_path] into [dest_path].
+
+    @since 2.8.0 *)
+val mv :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list ->
+  string -> string -> t
+
+(** [sh ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [sh] command.
+
+    Example:
+    {[sh {|
+set -eu
+
+VAR=hello
+echo "$VAR"|}]}
+
+    @since 2.8.0 *)
+val sh :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [zsh ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [zsh] command.
+
+    @since 2.8.0 *)
+val zsh :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [bash ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [bash] command.
+
+    @since 2.8.0 *)
+val bash :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [python2 ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [python2] command.
+
+    @since 2.8.0 *)
+val python2 :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [python3 ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [python3] command.
+
+    @since 2.8.0 *)
+val python3 :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [ruby ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [ruby] command.
+
+    @since 2.8.0 *)
+val ruby :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** [perl ?check ?capture_stdout ?capture_stderr ?interval ?args script]
+    evaluates a given code [script] by [perl] command.
+
+    @since 2.8.0 *)
+val perl :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  ?args:string list -> string -> t
+
+(** {2 Capturing} *)
+
+(** [capture_in_process ?check ?capture_stdout ?capture_stderr ?interval f]
+    captures data output to stdout/stderr during execution of a function [f].
+
+    NOTE: [capture_in_process] creates a new subprocess and evaluates [f] in the
+    subprocess. Therefore [f] cannot modify memory of the parent process.
+    For example, the following snippet results in [0], not [42].
+
+    {[let r = ref 0 in
+      let _ = capture_in_process (fun () -> r := 42) in
+      !r (* 0, not 42 *)]}
+
+    @param check           raises an execption when a process fails (default = [true])
+    @param capture_stdout  default = [true]
+    @param capture_stderr  default = [`No]
+    @param interval        timeout of [Unix.select] for waiting IO (default = [0.1] seconds)
+
+    @return an execution result of a subprocess.
+
+    @since 2.8.0 *)
+val capture_in_process :
+  ?check:bool ->
+  ?capture_stdout:bool ->
+  ?capture_stderr:capture_stderr_type ->
+  ?interval:float ->
+  (unit -> 'a) -> t

--- a/tests/integration/jupyter-notebook.ipynb
+++ b/tests/integration/jupyter-notebook.ipynb
@@ -10,6 +10,114 @@
     "\n",
     "Jupyter_notebook.display \"text/html\" \"<h1>Hello, World!</h1>\" ;;"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.sh {|pwd|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.zsh {|pwd|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.bash {|pwd|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.python2 {|print \"ok\"|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.python3 {|print(\"ok\")|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Process.ruby {|print \"ok\n\"|}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Bench.time (fun () -> 2. ** 1000.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Jupyter_notebook.Bench.timeit (fun () -> 2. ** 1000.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let r = Jupyter_notebook.Process.capture_in_process (fun () -> print_endline \"ok\") in\n",
+    "assert(r.exit_status = Unix.WEXITED 0) ;\n",
+    "assert(r.stdout = Some \"ok\\n\") ;\n",
+    "assert(r.stderr = None) ;\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let r = Jupyter_notebook.Process.capture_in_process ~capture_stderr:`Yes (fun () -> prerr_endline \"ok\") in\n",
+    "assert(r.exit_status = Unix.WEXITED 0) ;\n",
+    "assert(r.stdout = Some \"\") ;\n",
+    "assert(r.stderr = Some \"ok\\n\") ;\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let r = Jupyter_notebook.Process.capture_in_process ~capture_stderr:`Redirect_to_stdout (fun () -> prerr_endline \"ok\") in\n",
+    "assert(r.exit_status = Unix.WEXITED 0) ;\n",
+    "assert(r.stdout = Some \"ok\\n\") ;\n",
+    "assert(r.stderr = None) ;\n"
+   ]
   }
  ],
  "metadata": {

--- a/tests/notebook/dune
+++ b/tests/notebook/dune
@@ -1,0 +1,12 @@
+(executables
+ (names      test_notebook)
+ (modes      byte)
+ (preprocess (pps lwt_ppx ppx_deriving.show ppx_yojson_conv))
+ (libraries  jupyter_notebook
+             ounit2)
+ (flags      ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+
+(alias
+ (name   runtest)
+ (deps   test_notebook.bc)
+ (action (run %{dep:test_notebook.bc})))

--- a/tests/notebook/test_bench.ml
+++ b/tests/notebook/test_bench.ml
@@ -1,0 +1,69 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+open Format
+open OUnit2
+open Jupyter_notebook.Bench
+
+let test__time ctxt =
+  let actual_val, actual_time = time (fun () -> 2. ** 1000.) in
+  let expected_val = 1.07150860718626732e+301 in
+  assert_equal ~ctxt ~printer:[%show: float] expected_val actual_val ;
+  assert_equal ~msg:"real time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<)
+    0.0 actual_time.b_rtime ;
+  assert_equal ~msg:"user time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<)
+    0.0 actual_time.b_utime ;
+  assert_equal ~msg:"sys time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<=)
+    0.0 actual_time.b_stime ;
+  assert_equal ~msg:"real time probably is up to 5 sec"
+    ~ctxt ~printer:[%show: float] ~cmp:(>)
+    5.0 actual_time.b_rtime ;
+  assert_equal ~msg:"real time > user time"
+    ~ctxt ~printer:[%show: float] ~cmp:(>)
+    actual_time.b_rtime actual_time.b_utime ;
+  assert_equal ~msg:"real time > sys time"
+    ~ctxt ~printer:[%show: float] ~cmp:(>)
+    actual_time.b_rtime actual_time.b_stime
+
+let test__timeit ctxt =
+  let actual_time = timeit (fun () -> 2. ** 1000.) in
+  assert_equal ~msg:"mean of real time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<) 0.0 actual_time.b_rtime.bs_mean ;
+  assert_equal ~msg:"mean of user time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<) 0.0 actual_time.b_utime.bs_mean ;
+  assert_equal ~msg:"mean of sys time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<=) 0.0 actual_time.b_stime.bs_mean ;
+  assert_equal ~msg:"std dev of real time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<=) 0.0 actual_time.b_rtime.bs_std ;
+  assert_equal ~msg:"std dev of user time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<=) 0.0 actual_time.b_utime.bs_std ;
+  assert_equal ~msg:"std dev of sys time is positive"
+    ~ctxt ~printer:[%show: float] ~cmp:(<=) 0.0 actual_time.b_stime.bs_std
+
+let suite =
+  "Bench" >::: [
+    "time" >:: test__time;
+    "timeit" >:: test__timeit;
+  ]

--- a/tests/notebook/test_notebook.ml
+++ b/tests/notebook/test_notebook.ml
@@ -1,0 +1,32 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+open Format
+open OUnit2
+
+let suite =
+  "Jupyter_notebook" >::: [
+    Test_process.suite;
+    Test_bench.suite;
+  ]
+
+let () = run_test_tt_main suite

--- a/tests/notebook/test_process.ml
+++ b/tests/notebook/test_process.ml
@@ -1,0 +1,188 @@
+(* ocaml-jupyter --- An OCaml kernel for Jupyter
+
+   Copyright (c) 2017 Akinori ABE
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+open Format
+open OUnit2
+open Jupyter_notebook.Process
+
+let test__system_creates_a_process ctxt =
+  let res = system "/bin/sh" ["/bin/sh"; "-c"; ":"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__system_searches_a_program_in_PATH ctxt =
+  let res = system "sh" ["sh"; "-c"; ":"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__system_captures_stdout ctxt =
+  let res = system ~capture_stdout:true "echo" ["echo"; "foobaz"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "foobaz\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__system_captures_stderr ctxt =
+  let res = system ~capture_stderr:`Yes "sh" ["sh"; "-c"; "echo foobaz >&2"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "foobaz\n") res.stderr
+
+let test__system_captures_stderr_redirected_to_stdout ctxt =
+  let res = system ~capture_stderr:`Redirect_to_stdout "sh" ["sh"; "-c"; "echo foobaz >&2"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "foobaz\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__system_returns_nonzero_status_if_check_is_false ctxt =
+  let res = system ~check:false "test" ["test"; "1"; "-eq"; "2"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 1) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__system_raises_an_exception_if_check_is_true _ctxt =
+  assert_raises
+    (Execution_failure {
+        exit_status = Unix.WEXITED 1;
+        stdout = None;
+        stderr = None;
+      })
+    (fun () -> system ~check:true "test" ["test"; "1"; "-eq"; "2"])
+
+let test__sh ctxt =
+  let res = sh ~capture_stdout:true "echo ok" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__zsh ctxt =
+  let res = zsh ~capture_stdout:true "echo ok" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__bash ctxt =
+  let res = bash ~capture_stdout:true "echo ok" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__python2 ctxt =
+  let res = python2 ~capture_stdout:true "print 'ok'" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__python3 ctxt =
+  let res = python3 ~capture_stdout:true "print('ok')" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__ruby ctxt =
+  let res = ruby ~capture_stdout:true "print 'ok'" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__perl ctxt =
+  let res = ruby ~capture_stdout:true "print 'ok'" in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "ok") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__ls ctxt =
+  let res = ls ~capture_stdout:true ["./test_process.ml"] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+  assert_equal ~ctxt ~printer:[%show: string option] (Some "./test_process.ml\n") res.stdout ;
+  assert_equal ~ctxt ~printer:[%show: string option] None res.stderr
+
+let test__rm ctxt =
+  let filename = "./test__rm.txt" in
+  let oc = open_out filename in
+  close_out oc ;
+
+  let res = rm [filename] in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+
+  assert_equal ~msg:"A file doesn't exist after rm."
+    ~ctxt ~printer:[%show: bool] false (Sys.file_exists filename)
+
+let test__cp ctxt =
+  let src_path = "./test__cp1.txt" in
+  let dest_path = "./test__cp2.txt" in
+  let oc = open_out src_path in
+  output_string oc "Hello" ;
+  close_out oc ;
+
+  let res = cp src_path dest_path in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+
+  let ic = open_in dest_path in
+  let line = input_line ic in
+  close_in ic ;
+  assert_equal ~msg:"dest_path has the same contents as src_path."
+    ~ctxt ~printer:[%show: string] "Hello" line
+
+let test__mv ctxt =
+  let src_path = "./test__mv1.txt" in
+  let dest_path = "./test__mv2.txt" in
+  let oc = open_out src_path in
+  output_string oc "Hello" ;
+  close_out oc ;
+
+  let res = mv src_path dest_path in
+  assert_equal ~ctxt ~printer:[%show: process_status] (Unix.WEXITED 0) res.exit_status ;
+
+  let ic = open_in dest_path in
+  let line = input_line ic in
+  close_in ic ;
+  assert_equal ~msg:"dest_path has the same contents as src_path."
+    ~ctxt ~printer:[%show: string] "Hello" line
+  ;
+  assert_equal ~msg:"src_path doesn't exist after mv."
+    ~ctxt ~printer:[%show: bool] false (Sys.file_exists src_path)
+
+let suite =
+  "Process" >::: [
+    "system" >::: [
+      "creates a process" >:: test__system_creates_a_process;
+      "searches a program in $PATH" >:: test__system_searches_a_program_in_PATH;
+      "captures stdout" >:: test__system_captures_stdout;
+      "captures stderr" >:: test__system_captures_stderr;
+      "captures stderr redirected to stdout" >:: test__system_captures_stderr_redirected_to_stdout;
+      "returns non-zero status if check=false" >:: test__system_returns_nonzero_status_if_check_is_false;
+      "raises an exception if check=true" >:: test__system_raises_an_exception_if_check_is_true;
+    ];
+    "sh" >:: test__sh;
+    "zsh" >:: test__zsh;
+    "bash" >:: test__bash;
+    "python2" >:: test__python2;
+    "python3" >:: test__python3;
+    "ruby" >:: test__ruby;
+    "perl" >:: test__perl;
+    "ls" >:: test__ls;
+    "rm" >:: test__rm;
+    "cp" >:: test__cp;
+    "mv" >:: test__mv;
+  ]


### PR DESCRIPTION
[IPython magic](https://ipython.readthedocs.io/en/stable/interactive/magics.html) is special command available in IPython kernel. The magic provides helpful functionality such as calling external commands (bash, ruby, etc.), benchmarking, capturing of stdout/stderr, and so on. The syntax of the magics is different from the Python core language: they starts with % or %%, and arguments are written like --param.

OCaml Jupyter 2.8.0+ supports several utility functions inspired by IPython magics. Unlike IPython magics, the functions are implemented by the OCaml core language, not syntax extension. You don't need to study new syntax, and distinguish cell magics and line magics. The utility functions inherits convenience and flexibility of the OCaml language. They are included in jupyter.notebook package. You can see [API documentation of jupyter.notebook](https://akabe.github.io/ocaml-jupyter/api/jupyter/Jupyter_notebook/) for details.

- [x] `Jupyter_notebook.Process.system`
- [x] `Jupyter_notebook.Process.sh`
- [x] `Jupyter_notebook.Process.zsh`
- [x] `Jupyter_notebook.Process.bash`
- [x] `Jupyter_notebook.Process.python2`
- [x] `Jupyter_notebook.Process.python3`
- [x] `Jupyter_notebook.Process.ruby`
- [x] `Jupyter_notebook.Process.perl`
- [x] `Jupyter_notebook.Process.pwd`
- [x] `Jupyter_notebook.Process.cd`
- [x] `Jupyter_notebook.Process.ls`
- [x] `Jupyter_notebook.Process.cp`
- [x] `Jupyter_notebook.Process.rm`
- [x] `Jupyter_notebook.Process.mv`
- [x] `Jupyter_notebook.Process.capture_in_process`
- [x] `Jupyter_notebook.Bench.time`
- [x] `Jupyter_notebook.Bench.timeit`