### PR TITLE
Fix accidental regression in 4.14.1 Clflags

### DIFF
--- a/src/repl/caml_args.cppo.ml
+++ b/src/repl/caml_args.cppo.ml
@@ -210,8 +210,10 @@ module Options = Main_args.Make_bytetop_options (struct
     let _dno_locations = clear Clflags.locations
 #endif
 
-#if OCAML_VERSION >= (4,14,0)
+#if OCAML_VERSION = (4,14,0)
 let _force_tmc = set Clflags.force_tmc
+#endif
+#if OCAML_VERSION >= (4,14,0)
 let _dshape = set Clflags.dump_shape
 let _eval (_ : string) = ()
 #endif


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/11661 was cherry-picked to the 4.14.1 release, which causes an accidental regression for ocaml-jupyter.

This PR restores support for 4.14.1.