### PR TITLE
Replace workspace_root with project_root

### DIFF
--- a/src/comm/dune
+++ b/src/comm/dune
@@ -9,7 +9,7 @@
               Stdin)
  (flags       (:standard
                -thread
-               (:include %{workspace_root}/config/ocaml_flags.sexp)))
+               (:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps ppx_yojson_conv))
  (libraries   jupyter
               jupyter.notebook))

--- a/src/completor/dune
+++ b/src/completor/dune
@@ -4,7 +4,7 @@
  (modules     Jupyter_completor
               Merlin
               Intf)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps lwt_ppx ppx_yojson_conv))
  (libraries   jupyter
               jupyter_log

--- a/src/core/dune
+++ b/src/core/dune
@@ -11,6 +11,6 @@
               AnsiCode
               Json
               Version)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps ppx_yojson_conv))
  (libraries   unix uuidm ppx_yojson_conv_lib))

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -9,7 +9,7 @@
               Channel_intf
               Connection_info
               Hmac)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps lwt_ppx ppx_yojson_conv))
  (libraries   jupyter
               jupyter_repl

--- a/src/log/dune
+++ b/src/log/dune
@@ -2,6 +2,6 @@
  (name        jupyter_log)
  (synopsis    "A logging library for OCaml Jupyter kernel")
  (modules     Jupyter_log)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps lwt_ppx))
  (libraries   lwt lwt.unix logs logs.lwt))

--- a/src/main/dune
+++ b/src/main/dune
@@ -9,4 +9,4 @@
               jupyter_repl
               jupyter_completor
               jupyter_kernel)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp))))

--- a/src/notebook/dune
+++ b/src/notebook/dune
@@ -9,7 +9,7 @@
               Process
               Eval
               Unsafe)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (libraries   jupyter
               uuidm
               base64

--- a/src/repl/dune
+++ b/src/repl/dune
@@ -10,7 +10,7 @@
               Error
               Dir_trace
               Compat)
- (flags       ((:include %{workspace_root}/config/ocaml_flags.sexp)))
+ (flags       ((:include %{project_root}/config/ocaml_flags.sexp)))
  (preprocess  (pps lwt_ppx))
  (libraries   jupyter
               jupyter_log

--- a/tests/completor/dune
+++ b/tests/completor/dune
@@ -4,9 +4,9 @@
  (libraries  jupyter
              jupyter_completor
              ounit2)
- (flags      ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+ (flags      ((:include %{project_root}/config/ocaml_flags.sexp))))
 
 (alias
  (name   runtest)
  (deps   test_completor.exe)
- (action (chdir %{workspace_root}/test (run %{deps} -runner sequential))))
+ (action (chdir %{project_root}/test (run %{deps} -runner sequential))))

--- a/tests/kernel/dune
+++ b/tests/kernel/dune
@@ -5,9 +5,9 @@
  (libraries  jupyter
              jupyter_kernel
              ounit2)
- (flags      ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+ (flags      ((:include %{project_root}/config/ocaml_flags.sexp))))
 
 (alias
  (name   runtest)
  (deps   test_kernel.bc)
- (action (chdir %{workspace_root}/test (run %{deps} -runner sequential))))
+ (action (chdir %{project_root}/test (run %{deps} -runner sequential))))

--- a/tests/notebook/dune
+++ b/tests/notebook/dune
@@ -4,7 +4,7 @@
  (preprocess (pps lwt_ppx ppx_deriving.show ppx_yojson_conv))
  (libraries  jupyter_notebook
              ounit2)
- (flags      ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+ (flags      ((:include %{project_root}/config/ocaml_flags.sexp))))
 
 (alias
  (name   runtest)

--- a/tests/repl/dune
+++ b/tests/repl/dune
@@ -6,7 +6,7 @@
  (libraries  jupyter
              jupyter_repl
              ounit2)
- (flags      ((:include %{workspace_root}/config/ocaml_flags.sexp))))
+ (flags      ((:include %{project_root}/config/ocaml_flags.sexp))))
 
 (alias
  (name   runtest)
@@ -15,7 +15,7 @@
          ../fixtures/ocamlinit.ml
          ../fixtures/file.bin)
  (action
-  (chdir %{workspace_root}/tests
+  (chdir %{project_root}/tests
          (progn
            (run %{dep:test_evaluation.bc})
            (run %{dep:test_process.bc} -runner sequential)))))


### PR DESCRIPTION
The %{workspace_root} dune variable causes problems when the package is
vendored inside another package as it resolves to the root of the entire
workspace rather than the source of this project. Using ${project_root}
instead fixes this problem.
