### PR TITLE
Add open to expose yojson functions used in derives

### DIFF
--- a/src/completor/merlin.ml
+++ b/src/completor/merlin.ml
@@ -27,6 +27,7 @@
 open Format
 open Lwt.Infix
 open Jupyter_log
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 let string_of_bool b = if b then "y" else "n"
 

--- a/src/core/comm.ml
+++ b/src/core/comm.ml
@@ -20,6 +20,8 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 (** User-defined communication *)
 type t =
   {

--- a/src/core/iopub.ml
+++ b/src/core/iopub.ml
@@ -20,6 +20,8 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 (** Contents on IOPUB channels *)
 
 (** {2 Streams} *)

--- a/src/core/message.ml
+++ b/src/core/message.ml
@@ -20,6 +20,8 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 (** Messaging in Jupyter *)
 
 (** {2 Headers} *)

--- a/src/core/shell.ml
+++ b/src/core/shell.ml
@@ -20,6 +20,8 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 (** Contents on SHELL channels *)
 
 type status =

--- a/src/core/stdin.ml
+++ b/src/core/stdin.ml
@@ -20,6 +20,8 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
 (** Contents on STDIN channel *)
 
 (** {2 Inputs} *)

--- a/src/kernel/connection_info.ml
+++ b/src/kernel/connection_info.ml
@@ -23,6 +23,7 @@
 (** Connection information *)
 
 open Jupyter_log
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 (** The type of connection information.
 

--- a/tests/integration/ppx.ipynb
+++ b/tests/integration/ppx.ipynb
@@ -8,6 +8,8 @@
    "source": [
     "#require \"ppx_yojson_conv\" ;;\n",
     "\n",
+    "open Ppx_yojson_conv_lib.Yojson_conv.Primitives\n",
+    "\n",
     "type t = { foo : int; baz : string; } [@@deriving yojson]\n",
     "\n",
     "let expected = \"{\\\"foo\\\":42,\\\"baz\\\":\\\"hello\\\"}\"\n",


### PR DESCRIPTION
Fixes https://github.com/akabe/ocaml-jupyter/issues/200.

I tried running some tests as best as I can but I'm not sure if the test failures I'm getting are relevant to https://github.com/akabe/ocaml-jupyter/issues/200.