### PR TITLE
Update `Manager` Comms link

### DIFF
--- a/src/comm/manager.mli
+++ b/src/comm/manager.mli
@@ -26,7 +26,7 @@
 
 (** This module provides communication of arbitrary JSON data between the OCaml
     REPL and the Jupyter.
-    See {{:http://jupyter-notebook.readthedocs.io/en/latest/comms.html}
+    See {{:https://jupyter-client.readthedocs.io/en/stable/messaging.html#custom-messages}
     Comms (Jupyter Notebook Docs)} for details.
 
     {2 Opening a comm from the REPL}


### PR DESCRIPTION
Updated `Manager` Comms link from 404 link to what I believe is the most relevant documentation per [Wayback Machine](https://web.archive.org/web/20180801090118/http://jupyter-notebook.readthedocs.io/en/latest/comms.html).